### PR TITLE
feat: Phase S2 - Gateway deployment

### DIFF
--- a/ansible/roles/gateway/handlers/main.yml
+++ b/ansible/roles/gateway/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+# Gateway role handlers
+
+- name: Reload systemd
+  become: true
+  ansible.builtin.systemd:
+    daemon_reload: true

--- a/ansible/roles/gateway/tasks/main.yml
+++ b/ansible/roles/gateway/tasks/main.yml
@@ -1,37 +1,200 @@
 ---
 # Gateway Role - Phase S2
-# Installs Node.js, OpenClaw, and configures the gateway service
-#
-# TODO (Phase S2):
-# - Install Node.js via nvm or nodesource
-# - Create openclaw user
-# - Install OpenClaw from /mnt/openclaw
-# - Configure systemd service
-# - Set up ~/.openclaw directory structure
+# Installs Node.js, builds OpenClaw, and configures the gateway service
 
-- name: Gateway role placeholder
+- name: Install prerequisites
+  become: true
+  ansible.builtin.apt:
+    name:
+      - unzip
+      - curl
+    state: present
+    update_cache: true
+
+- name: Check if Node.js is installed
+  ansible.builtin.command: node --version
+  register: node_version
+  changed_when: false
+  failed_when: false
+
+- name: Install Node.js via NodeSource (if not installed)
+  when: node_version.rc != 0
+  block:
+    - name: Download NodeSource setup script
+      ansible.builtin.get_url:
+        url: https://deb.nodesource.com/setup_22.x
+        dest: /tmp/nodesource_setup.sh
+        mode: "0755"
+
+    - name: Run NodeSource setup script
+      ansible.builtin.command: bash /tmp/nodesource_setup.sh
+      become: true
+
+    - name: Install Node.js
+      ansible.builtin.apt:
+        name: nodejs
+        state: present
+        update_cache: true
+      become: true
+
+    - name: Clean up setup script
+      ansible.builtin.file:
+        path: /tmp/nodesource_setup.sh
+        state: absent
+
+- name: Verify Node.js installation
+  ansible.builtin.command: node --version
+  register: node_installed_version
+  changed_when: false
+
+- name: Display Node.js version
   ansible.builtin.debug:
-    msg: "Gateway role - Phase S2 (not yet implemented)"
+    msg: "Node.js version: {{ node_installed_version.stdout }}"
 
-# Placeholder tasks for Phase S2:
-#
-# - name: Install Node.js prerequisites
-#   ansible.builtin.apt:
-#     name:
-#       - curl
-#       - ca-certificates
-#     state: present
-#
-# - name: Create openclaw user
-#   ansible.builtin.user:
-#     name: "{{ openclaw_user }}"
-#     home: "{{ openclaw_home }}"
-#     shell: /bin/bash
-#     create_home: true
-#
-# - name: Create OpenClaw config directory
-#   ansible.builtin.file:
-#     path: "{{ openclaw_config_dir }}"
-#     state: directory
-#     owner: "{{ openclaw_user }}"
-#     mode: "0750"
+# Install bun for faster package management
+- name: Check if bun is installed
+  ansible.builtin.command: "{{ ansible_env.HOME }}/.bun/bin/bun --version"
+  register: bun_version
+  changed_when: false
+  failed_when: false
+
+- name: Install bun (if not installed)
+  when: bun_version.rc != 0
+  ansible.builtin.shell: |
+    curl -fsSL https://bun.sh/install | bash
+  args:
+    creates: "{{ ansible_env.HOME }}/.bun/bin/bun"
+
+# Handle config/auth - link from mount or create fresh
+- name: Check if config mount exists
+  ansible.builtin.stat:
+    path: /mnt/openclaw-config
+  register: config_mount
+
+- name: Check if ~/.openclaw exists
+  ansible.builtin.stat:
+    path: "{{ ansible_env.HOME }}/.openclaw"
+  register: openclaw_config
+
+- name: Link config from mount (if mounted and no existing config)
+  when: config_mount.stat.exists and not openclaw_config.stat.exists
+  ansible.builtin.file:
+    src: /mnt/openclaw-config
+    dest: "{{ ansible_env.HOME }}/.openclaw"
+    state: link
+
+- name: Create ~/.openclaw directory (if no mount and no existing)
+  when: not config_mount.stat.exists and not openclaw_config.stat.exists
+  ansible.builtin.file:
+    path: "{{ ansible_env.HOME }}/.openclaw"
+    state: directory
+    mode: "0750"
+
+- name: Display config status
+  ansible.builtin.debug:
+    msg: >-
+      Config status:
+      {% if config_mount.stat.exists %}
+      Using mounted config from host
+      {% elif openclaw_config.stat.exists %}
+      Using existing config
+      {% else %}
+      Fresh config directory created - run onboard to configure
+      {% endif %}
+
+# Install OpenClaw dependencies
+- name: Check if node_modules exists
+  ansible.builtin.stat:
+    path: /mnt/openclaw/node_modules
+  register: node_modules
+
+- name: Install OpenClaw dependencies (using bun)
+  when: not node_modules.stat.exists
+  ansible.builtin.shell: |
+    export PATH="{{ ansible_env.HOME }}/.bun/bin:$PATH"
+    cd /mnt/openclaw && bun install
+  args:
+    creates: /mnt/openclaw/node_modules
+
+# Build OpenClaw (if not already built)
+- name: Check if dist exists
+  ansible.builtin.stat:
+    path: /mnt/openclaw/dist/index.js
+  register: dist_exists
+
+- name: Build OpenClaw
+  when: not dist_exists.stat.exists
+  ansible.builtin.shell: |
+    export PATH="{{ ansible_env.HOME }}/.bun/bin:$PATH"
+    cd /mnt/openclaw && bun run build
+  args:
+    creates: /mnt/openclaw/dist/index.js
+
+# Create systemd service for gateway
+- name: Create gateway systemd service
+  become: true
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/openclaw-gateway.service
+    mode: "0644"
+    content: |
+      [Unit]
+      Description=OpenClaw Gateway
+      After=network.target
+
+      [Service]
+      Type=simple
+      User={{ ansible_user }}
+      WorkingDirectory=/mnt/openclaw
+      Environment=HOME={{ ansible_env.HOME }}
+      Environment=PATH={{ ansible_env.HOME }}/.bun/bin:/usr/local/bin:/usr/bin:/bin
+      ExecStart=/usr/bin/node dist/index.js gateway --bind 0.0.0.0 --port 18789
+      Restart=on-failure
+      RestartSec=5
+
+      [Install]
+      WantedBy=multi-user.target
+  notify: Reload systemd
+
+- name: Enable gateway service
+  become: true
+  ansible.builtin.systemd:
+    name: openclaw-gateway
+    enabled: true
+    daemon_reload: true
+
+# Check if onboard has been completed
+- name: Check if gateway is configured
+  ansible.builtin.stat:
+    path: "{{ ansible_env.HOME }}/.openclaw/config.json"
+  register: gateway_config
+
+- name: Gateway configuration status
+  ansible.builtin.debug:
+    msg: >-
+      {% if gateway_config.stat.exists %}
+      Gateway is configured. Starting service...
+      {% else %}
+      Gateway NOT configured. Run: ./bootstrap.sh --onboard
+      {% endif %}
+
+# Only start if configured
+- name: Start gateway service (if configured)
+  become: true
+  when: gateway_config.stat.exists
+  ansible.builtin.systemd:
+    name: openclaw-gateway
+    state: started
+
+- name: Gateway not started (needs onboard)
+  when: not gateway_config.stat.exists
+  ansible.builtin.debug:
+    msg: |
+      ============================================
+      Gateway installed but NOT started.
+
+      To configure the gateway, run:
+        ./bootstrap.sh --onboard
+
+      Then re-run bootstrap to start the service:
+        ./bootstrap.sh
+      ============================================


### PR DESCRIPTION
## Summary

Phase S2 implementation - actually installs and configures the OpenClaw gateway in the VM.

### Gateway Role
- Installs Node.js 22 via NodeSource
- Installs bun for faster package management
- Creates systemd service `openclaw-gateway` (enabled, starts on config)
- Links config from `/mnt/openclaw-config` if host config is mounted
- Detects if onboard is needed before starting

### Bootstrap.sh Additions
- `--config PATH`: Mount host `~/.openclaw` for auth/credentials
- `--shell`: Open interactive shell in the VM
- `--onboard`: Run interactive `openclaw onboard` in the VM

### Workflow

**Fresh setup (no existing config):**
```bash
./bootstrap.sh --openclaw ~/Projects/openclaw
./bootstrap.sh --onboard    # Interactive setup
./bootstrap.sh              # Starts gateway
```

**With existing config:**
```bash
./bootstrap.sh --openclaw ~/Projects/openclaw --config ~/.openclaw
# Gateway starts automatically
```

## Test plan

- [x] Node.js 22 installs correctly
- [x] Bun installs correctly
- [x] Systemd service created and enabled
- [ ] `--onboard` runs interactive setup
- [ ] Gateway starts after onboard
- [ ] `--config` mount works for existing auth

## Path to secrets (Phase S5)

Currently: Mount host `~/.openclaw` via `--config`
Future: Secrets role injects credentials at provision time, no mount needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)