### PR TITLE
fix(gateway): handle edge cases and deprecation warnings

### DIFF
--- a/ansible/roles/gateway/tasks/main.yml
+++ b/ansible/roles/gateway/tasks/main.yml
@@ -53,7 +53,7 @@
 
 # Install bun for faster package management
 - name: Check if bun is installed
-  ansible.builtin.command: "{{ ansible_env.HOME }}/.bun/bin/bun --version"
+  ansible.builtin.command: "{{ ansible_facts['env']['HOME'] }}/.bun/bin/bun --version"
   register: bun_version
   changed_when: false
   failed_when: false
@@ -63,7 +63,7 @@
   ansible.builtin.shell: |
     curl -fsSL https://bun.sh/install | bash
   args:
-    creates: "{{ ansible_env.HOME }}/.bun/bin/bun"
+    creates: "{{ ansible_facts['env']['HOME'] }}/.bun/bin/bun"
 
 # Handle config/auth - link from mount or create fresh
 - name: Check if config mount exists
@@ -73,20 +73,45 @@
 
 - name: Check if ~/.openclaw exists
   ansible.builtin.stat:
-    path: "{{ ansible_env.HOME }}/.openclaw"
+    path: "{{ ansible_facts['env']['HOME'] }}/.openclaw"
   register: openclaw_config
 
+# Fix: Handle existing empty directory - replace with symlink if mount available
+- name: Check if ~/.openclaw is empty directory (not symlink)
+  when: openclaw_config.stat.exists and openclaw_config.stat.isdir and not openclaw_config.stat.islnk
+  ansible.builtin.find:
+    paths: "{{ ansible_facts['env']['HOME'] }}/.openclaw"
+    file_type: any
+  register: openclaw_config_contents
+
+- name: Remove empty ~/.openclaw directory (to replace with symlink)
+  when: >
+    config_mount.stat.exists and
+    openclaw_config.stat.exists and
+    openclaw_config.stat.isdir and
+    not openclaw_config.stat.islnk and
+    (openclaw_config_contents.matched | default(0)) == 0
+  ansible.builtin.file:
+    path: "{{ ansible_facts['env']['HOME'] }}/.openclaw"
+    state: absent
+
+# Re-check after potential removal
+- name: Re-check ~/.openclaw after cleanup
+  ansible.builtin.stat:
+    path: "{{ ansible_facts['env']['HOME'] }}/.openclaw"
+  register: openclaw_config_recheck
+
 - name: Link config from mount (if mounted and no existing config)
-  when: config_mount.stat.exists and not openclaw_config.stat.exists
+  when: config_mount.stat.exists and not openclaw_config_recheck.stat.exists
   ansible.builtin.file:
     src: /mnt/openclaw-config
-    dest: "{{ ansible_env.HOME }}/.openclaw"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.openclaw"
     state: link
 
 - name: Create ~/.openclaw directory (if no mount and no existing)
-  when: not config_mount.stat.exists and not openclaw_config.stat.exists
+  when: not config_mount.stat.exists and not openclaw_config_recheck.stat.exists
   ansible.builtin.file:
-    path: "{{ ansible_env.HOME }}/.openclaw"
+    path: "{{ ansible_facts['env']['HOME'] }}/.openclaw"
     state: directory
     mode: "0750"
 
@@ -103,18 +128,49 @@
       {% endif %}
 
 # Install OpenClaw dependencies
+# Fix: Detect platform mismatch (macOS modules don't work on Linux)
 - name: Check if node_modules exists
   ansible.builtin.stat:
     path: /mnt/openclaw/node_modules
   register: node_modules
 
+- name: Check node_modules platform marker
+  when: node_modules.stat.exists
+  ansible.builtin.stat:
+    path: /mnt/openclaw/node_modules/.linux-installed
+  register: linux_marker
+
+- name: Detect platform mismatch (reinstall if built on different platform)
+  when: node_modules.stat.exists and not (linux_marker.stat.exists | default(false))
+  block:
+    - name: Clear existing node_modules (platform mismatch)
+      ansible.builtin.file:
+        path: /mnt/openclaw/node_modules
+        state: absent
+
+    - name: Clear bun lockb (to force fresh install)
+      ansible.builtin.file:
+        path: /mnt/openclaw/bun.lockb
+        state: absent
+      failed_when: false
+
+- name: Re-check node_modules after potential cleanup
+  ansible.builtin.stat:
+    path: /mnt/openclaw/node_modules
+  register: node_modules_recheck
+
 - name: Install OpenClaw dependencies (using bun)
-  when: not node_modules.stat.exists
+  when: not node_modules_recheck.stat.exists
   ansible.builtin.shell: |
-    export PATH="{{ ansible_env.HOME }}/.bun/bin:$PATH"
+    export PATH="{{ ansible_facts['env']['HOME'] }}/.bun/bin:$PATH"
     cd /mnt/openclaw && bun install
-  args:
-    creates: /mnt/openclaw/node_modules
+    touch /mnt/openclaw/node_modules/.linux-installed
+  register: bun_install_result
+
+- name: Display bun install result
+  when: bun_install_result is defined and bun_install_result.changed
+  ansible.builtin.debug:
+    msg: "Dependencies installed for Linux platform"
 
 # Build OpenClaw (if not already built)
 - name: Check if dist exists
@@ -125,7 +181,7 @@
 - name: Build OpenClaw
   when: not dist_exists.stat.exists
   ansible.builtin.shell: |
-    export PATH="{{ ansible_env.HOME }}/.bun/bin:$PATH"
+    export PATH="{{ ansible_facts['env']['HOME'] }}/.bun/bin:$PATH"
     cd /mnt/openclaw && bun run build
   args:
     creates: /mnt/openclaw/dist/index.js
@@ -145,9 +201,9 @@
       Type=simple
       User={{ ansible_user }}
       WorkingDirectory=/mnt/openclaw
-      Environment=HOME={{ ansible_env.HOME }}
-      Environment=PATH={{ ansible_env.HOME }}/.bun/bin:/usr/local/bin:/usr/bin:/bin
-      ExecStart=/usr/bin/node dist/index.js gateway --bind 0.0.0.0 --port 18789 --allow-unconfigured
+      Environment=HOME={{ ansible_facts['env']['HOME'] }}
+      Environment=PATH={{ ansible_facts['env']['HOME'] }}/.bun/bin:/usr/local/bin:/usr/bin:/bin
+      ExecStart=/usr/bin/node dist/index.js gateway --bind lan --port 18789 --allow-unconfigured
       Restart=on-failure
       RestartSec=5
 
@@ -165,7 +221,7 @@
 # Check if onboard has been completed
 - name: Check if gateway is configured
   ansible.builtin.stat:
-    path: "{{ ansible_env.HOME }}/.openclaw/config.json"
+    path: "{{ ansible_facts['env']['HOME'] }}/.openclaw/config.json"
   register: gateway_config
 
 - name: Gateway configuration status


### PR DESCRIPTION
## Summary

- Fix empty `~/.openclaw` directory handling: detect and remove empty directories to allow symlink creation when config mount is available
- Fix node_modules platform mismatch: detect macOS-built modules and reinstall for Linux VM using `.linux-installed` marker file
- Fix `--bind` flag: use `lan` instead of `0.0.0.0` per OpenClaw gateway API
- Fix Ansible deprecation warnings: use `ansible_facts['env']['HOME']` instead of deprecated `ansible_env.HOME` (removed in ansible-core 2.24)

## Test plan

- [ ] Run `./bootstrap.sh --delete && ./bootstrap.sh` to test fresh VM provisioning
- [ ] Verify no deprecation warnings appear in Ansible output
- [ ] Verify node_modules are reinstalled (check for `.linux-installed` marker)
- [ ] Verify gateway starts correctly with `--bind lan` option

🤖 Generated with [Claude Code](https://claude.com/claude-code)