### PR TITLE
fix(sandbox): restore file ownership + agent identity persistence

### DIFF
--- a/ansible/roles/gateway/defaults/main.yml
+++ b/ansible/roles/gateway/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# Gateway Role Defaults
+
+# Identity directories to copy from config mount into ~/.openclaw/
+# These contain agent identity and state that must persist across VM recreations.
+config_identity_dirs:
+  - identity
+  - credentials
+  - dotfiles

--- a/ansible/roles/gateway/tasks/fix-vm-paths.yml
+++ b/ansible/roles/gateway/tasks/fix-vm-paths.yml
@@ -71,7 +71,7 @@
         state: directory
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
-        mode: "0750"
+        mode: "0755"
 
     - name: Display path fixes applied
       ansible.builtin.debug:

--- a/ansible/roles/gateway/tasks/main.yml
+++ b/ansible/roles/gateway/tasks/main.yml
@@ -131,6 +131,24 @@
   loop_control:
     label: "{{ item.path | basename }}"
 
+# Copy identity subdirectories from mount (device auth, credentials, dotfiles)
+# These contain agent identity state that must survive VM recreation:
+#   identity/   — device-auth.json, device.json (gateway device identity)
+#   credentials/ — telegram-allowFrom.json, telegram-pairing.json (pairing state)
+#   dotfiles/   — env.sh, gateway.sh, setup.sh (runtime scripts)
+- name: Copy identity directories from config mount
+  when: config_mount.stat.exists
+  ansible.builtin.copy:
+    src: "/mnt/openclaw-config/{{ item }}/"
+    dest: "{{ user_home }}/.openclaw/{{ item }}/"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    remote_src: true
+  loop: "{{ config_identity_dirs }}"
+  loop_control:
+    label: "{{ item }}"
+  failed_when: false
+
 # Agent data persistence: symlink to writable mount
 - name: Check if agent data mount exists
   ansible.builtin.stat:

--- a/ansible/roles/sandbox/tasks/main.yml
+++ b/ansible/roles/sandbox/tasks/main.yml
@@ -260,6 +260,8 @@
       ansible.builtin.copy:
         content: "{{ openclaw_config | to_nice_json }}"
         dest: "{{ user_home }}/.openclaw/openclaw.json"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
         mode: "0640"
       notify: Restart gateway
 
@@ -267,6 +269,8 @@
       when: not openclaw_json.stat.exists
       ansible.builtin.copy:
         dest: "{{ user_home }}/.openclaw/openclaw.json"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
         mode: "0640"
         content: |
           {


### PR DESCRIPTION
## Summary

- **Root cause**: Sandbox role wrote `openclaw.json` as `root:root` (missing `owner`/`group` on `ansible.builtin.copy`). Gateway runs as `openclaw` user → EACCES → all downstream config blind
- **Identity loss**: Gateway only copied `*.json` from config mount root. Subdirectories (`identity/`, `credentials/`, `dotfiles/`) were silently dropped on every reprovision
- **Workspace perms**: `~/.openclaw/workspace` was `0750`, blocking Docker container users with non-matching UIDs

## What broke (all traced to one missing `owner:` line)

| Symptom | Mechanism |
|---|---|
| GH_TOKEN invisible to agent | Gateway can't read `sandbox.docker.env.GH_TOKEN` from root-owned config |
| Obsidian vault unreadable | Gateway can't read `sandbox.docker.binds` with vault mount |
| Workspace inaccessible | Gateway can't read workspace/sandbox config at all |
| Device identity lost | `identity/device-auth.json` never copied from host |
| Telegram pairing lost | `credentials/telegram-allowFrom.json` never copied |

## Changes

| File | Fix |
|---|---|
| `ansible/roles/sandbox/tasks/main.yml` | Add `owner`/`group` to both `openclaw.json` write tasks |
| `ansible/roles/gateway/tasks/main.yml` | Copy `identity/`, `credentials/`, `dotfiles/` from config mount |
| `ansible/roles/gateway/defaults/main.yml` | New — configurable `config_identity_dirs` list |
| `ansible/roles/gateway/tasks/fix-vm-paths.yml` | Workspace dir `0750` → `0755` |
| `tests/sandbox/test-sandbox-ansible.sh` | +3 ownership regression checks (92/92 pass) |
| `tests/gateway/test-gateway-ansible.sh` | +7 identity + workspace checks (29/29 pass) |

## Test plan

- [x] `tests/sandbox/test-sandbox-ansible.sh` — 92/92 pass
- [x] `tests/gateway/test-gateway-ansible.sh` — 29/29 pass
- [ ] Reprovision VM and verify: gateway reads config, agent gets GH_TOKEN, vault mounted, identity persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)