### PR TITLE
fix: auto-export secrets in shell + rsync vault past iCloud locks

### DIFF
--- a/ansible/roles/overlay/tasks/main.yml
+++ b/ansible/roles/overlay/tasks/main.yml
@@ -85,6 +85,14 @@
             state: directory
             mode: "0755"
 
+        - name: Fix obsidian overlay upper directory ownership
+          ansible.builtin.file:
+            path: "{{ overlay_upper_base }}/obsidian/upper"
+            state: directory
+            owner: "{{ ansible_user }}"
+            group: "{{ ansible_user }}"
+            mode: "0755"
+
         - name: Deploy obsidian overlay mount unit
           ansible.builtin.template:
             src: workspace-obsidian.mount.j2

--- a/ansible/roles/secrets/tasks/main.yml
+++ b/ansible/roles/secrets/tasks/main.yml
@@ -197,7 +197,30 @@
         force: false
       when: not (has_any_secrets | bool)
 
-    # Step 6: Display status (no secret values)
+    # Step 6: Deploy /etc/profile.d script for shell sessions
+    # secrets.env uses plain KEY=VALUE (no export) for systemd EnvironmentFile=.
+    # This profile.d script sources it with set -a so child processes see the vars.
+    - name: Deploy secrets profile.d script
+      become: true
+      ansible.builtin.template:
+        src: openclaw-secrets.sh.j2
+        dest: /etc/profile.d/openclaw-secrets.sh
+        mode: "0644"
+        owner: root
+        group: root
+
+    # limactl shell spawns non-login bash which reads /etc/bash.bashrc
+    # but does NOT source /etc/profile.d/. Add a one-line hook.
+    - name: Ensure bash.bashrc sources openclaw secrets
+      become: true
+      ansible.builtin.lineinfile:
+        path: /etc/bash.bashrc
+        line: '[ -r /etc/profile.d/openclaw-secrets.sh ] && . /etc/profile.d/openclaw-secrets.sh'
+        regexp: 'openclaw-secrets\.sh'
+        insertafter: EOF
+        state: present
+
+    # Step 7: Display status (no secret values)
     - name: Display secrets provisioning status
       ansible.builtin.debug:
         msg: |

--- a/ansible/roles/secrets/templates/openclaw-secrets.sh.j2
+++ b/ansible/roles/secrets/templates/openclaw-secrets.sh.j2
@@ -1,0 +1,11 @@
+# {{ ansible_managed }}
+# Auto-export OpenClaw secrets for interactive shells.
+# systemd services use EnvironmentFile= directly; this covers shells.
+#
+# Sourced by: /etc/profile (login shells) and /etc/bash.bashrc (non-login shells)
+
+if [ -r {{ secrets_env_file }} ]; then
+    set -a
+    . {{ secrets_env_file }}
+    set +a
+fi

--- a/cli/tests/test_orchestrator.py
+++ b/cli/tests/test_orchestrator.py
@@ -1,5 +1,6 @@
 """Tests for orchestrator — the top-level up flow."""
 
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch, call
 
@@ -8,7 +9,7 @@ import pytest
 from sandbox_cli.lima_config import LimaConfigContext
 from sandbox_cli.lima_manager import LimaError, LimaManager, SSHDetails
 from sandbox_cli.models import SandboxProfile
-from sandbox_cli.orchestrator import orchestrate_up
+from sandbox_cli.orchestrator import orchestrate_up, _sync_vault
 
 
 # ── fixtures ─────────────────────────────────────────────────────────────
@@ -195,3 +196,109 @@ class TestOrchestrateUpFailures:
              patch("sandbox_cli.orchestrator.print_post_bootstrap"):
             rc = orchestrate_up(profile, bootstrap_dir, lima=mock_lima)
         assert rc == 0
+
+
+# ── vault sync ──────────────────────────────────────────────────────────
+
+
+class TestSyncVault:
+    @pytest.fixture
+    def vault_dir(self, tmp_path):
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (vault / "daily.md").write_text("# daily")
+        return vault
+
+    @pytest.fixture
+    def vault_profile(self, tmp_path, vault_dir):
+        oc = tmp_path / "openclaw"
+        oc.mkdir()
+        return SandboxProfile.model_validate(
+            {"mounts": {"openclaw": str(oc), "vault": str(vault_dir)}}
+        )
+
+    @pytest.fixture
+    def ssh(self):
+        return SSHDetails(
+            host="127.0.0.1", port=52345, user="test", key_path="/tmp/key"
+        )
+
+    def test_sync_calls_rsync(self, vault_profile, vault_dir, ssh):
+        with patch("sandbox_cli.orchestrator.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            from rich.console import Console
+            from io import StringIO
+            _sync_vault(vault_profile, ssh, Console(file=StringIO()))
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert args[0] == "rsync"
+        assert "-a" in args
+        assert "--delete" in args
+        assert f"{vault_dir}/" in args
+        assert "test@127.0.0.1:/var/lib/openclaw/overlay/obsidian/upper/" in args
+
+    def test_sync_uses_ssh_details(self, vault_profile, vault_dir, ssh):
+        with patch("sandbox_cli.orchestrator.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            from rich.console import Console
+            from io import StringIO
+            _sync_vault(vault_profile, ssh, Console(file=StringIO()))
+        args = mock_run.call_args[0][0]
+        ssh_arg = args[args.index("-e") + 1]
+        assert "-p 52345" in ssh_arg
+        assert "-i /tmp/key" in ssh_arg
+
+    def test_sync_skips_when_vault_dir_missing(self, tmp_path, ssh):
+        profile = SandboxProfile.model_validate(
+            {"mounts": {"openclaw": str(tmp_path), "vault": "/nonexistent/path"}}
+        )
+        with patch("sandbox_cli.orchestrator.subprocess.run") as mock_run:
+            from rich.console import Console
+            from io import StringIO
+            _sync_vault(profile, ssh, Console(file=StringIO()))
+        mock_run.assert_not_called()
+
+    def test_sync_handles_rsync_failure(self, vault_profile, vault_dir, ssh):
+        with patch("sandbox_cli.orchestrator.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stderr="rsync error")
+            from rich.console import Console
+            from io import StringIO
+            buf = StringIO()
+            _sync_vault(vault_profile, ssh, Console(file=buf))
+        # Should not raise — failure is non-fatal
+        output = buf.getvalue()
+        assert "failed" in output.lower()
+
+    def test_orchestrate_up_calls_vault_sync(self, vault_profile, bootstrap_dir, mock_lima):
+        """Vault sync runs after ansible when vault is configured."""
+        with patch("sandbox_cli.orchestrator.check_brew"), \
+             patch("sandbox_cli.orchestrator.install_brew_deps", return_value=0), \
+             patch("sandbox_cli.orchestrator.install_ansible_collections", return_value=0), \
+             patch("sandbox_cli.orchestrator.run_playbook", return_value=0), \
+             patch("sandbox_cli.orchestrator.print_post_bootstrap"), \
+             patch("sandbox_cli.orchestrator._sync_vault") as mock_sync:
+            orchestrate_up(vault_profile, bootstrap_dir, lima=mock_lima)
+        mock_sync.assert_called_once()
+
+    def test_orchestrate_up_skips_vault_sync_without_vault(self, profile, bootstrap_dir, mock_lima):
+        """No vault in profile → no vault sync."""
+        with patch("sandbox_cli.orchestrator.check_brew"), \
+             patch("sandbox_cli.orchestrator.install_brew_deps", return_value=0), \
+             patch("sandbox_cli.orchestrator.install_ansible_collections", return_value=0), \
+             patch("sandbox_cli.orchestrator.run_playbook", return_value=0), \
+             patch("sandbox_cli.orchestrator.print_post_bootstrap"), \
+             patch("sandbox_cli.orchestrator._sync_vault") as mock_sync:
+            orchestrate_up(profile, bootstrap_dir, lima=mock_lima)
+        mock_sync.assert_not_called()
+
+    def test_orchestrate_up_skips_vault_sync_in_yolo_unsafe(self, vault_profile, bootstrap_dir, mock_lima):
+        """yolo_unsafe → no overlay → no vault sync needed."""
+        vault_profile.mode.yolo_unsafe = True
+        with patch("sandbox_cli.orchestrator.check_brew"), \
+             patch("sandbox_cli.orchestrator.install_brew_deps", return_value=0), \
+             patch("sandbox_cli.orchestrator.install_ansible_collections", return_value=0), \
+             patch("sandbox_cli.orchestrator.run_playbook", return_value=0), \
+             patch("sandbox_cli.orchestrator.print_post_bootstrap"), \
+             patch("sandbox_cli.orchestrator._sync_vault") as mock_sync:
+            orchestrate_up(vault_profile, bootstrap_dir, lima=mock_lima)
+        mock_sync.assert_not_called()

--- a/scripts/sync-vault.sh
+++ b/scripts/sync-vault.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# sync-vault.sh - Sync Obsidian vault from host into VM overlay
+#
+# Usage: ./scripts/sync-vault.sh [VAULT_PATH]
+#
+# Bypasses virtiofs iCloud file coordination locks by using rsync over SSH.
+# The overlay upper directory receives the copies, so /workspace-obsidian/
+# serves host-readable files instead of hitting the locked virtiofs mount.
+#
+# To set up periodic sync (every 5 minutes):
+#   crontab -e
+#   */5 * * * * /path/to/openclaw-sandbox/scripts/sync-vault.sh >> /tmp/vault-sync.log 2>&1
+
+set -euo pipefail
+
+VM_NAME="openclaw-sandbox"
+TARGET_DIR="/var/lib/openclaw/overlay/obsidian/upper"
+
+# Resolve vault path: argument > profile > default
+if [[ -n "${1:-}" ]]; then
+    VAULT_PATH="$1"
+elif command -v python3 &>/dev/null; then
+    # Try reading from sandbox profile
+    VAULT_PATH=$(python3 -c "
+import tomllib, pathlib, os
+p = pathlib.Path(os.path.expanduser('~/.openclaw/sandbox-profile.toml'))
+if p.exists():
+    d = tomllib.loads(p.read_text())
+    v = d.get('mounts', {}).get('vault', '')
+    if v:
+        print(os.path.expanduser(v))
+" 2>/dev/null || true)
+fi
+
+if [[ -z "${VAULT_PATH:-}" ]]; then
+    echo "ERROR: No vault path. Pass as argument or set mounts.vault in sandbox profile."
+    exit 1
+fi
+
+# Verify vault exists
+if [[ ! -d "$VAULT_PATH" ]]; then
+    echo "ERROR: Vault path does not exist: $VAULT_PATH"
+    exit 1
+fi
+
+# Verify VM is running
+if ! limactl list --json 2>/dev/null | python3 -c "
+import json, sys
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    obj = json.loads(line)
+    if obj.get('name') == '${VM_NAME}' and obj.get('status') == 'Running':
+        sys.exit(0)
+sys.exit(1)
+" 2>/dev/null; then
+    echo "ERROR: VM '${VM_NAME}' is not running"
+    exit 1
+fi
+
+# Get SSH details
+SSH_CONFIG=$(limactl show-ssh --format=config "$VM_NAME" 2>/dev/null)
+SSH_HOST=$(echo "$SSH_CONFIG" | grep -m1 'Hostname ' | awk '{print $2}')
+SSH_PORT=$(echo "$SSH_CONFIG" | grep -m1 'Port ' | awk '{print $2}')
+SSH_USER=$(echo "$SSH_CONFIG" | grep -m1 'User ' | awk '{print $2}')
+SSH_KEY=$(echo "$SSH_CONFIG" | grep -m1 'IdentityFile ' | awk '{print $2}' | tr -d '"')
+
+echo "[$(date -Iseconds)] Syncing vault: $VAULT_PATH -> $VM_NAME:$TARGET_DIR"
+
+rsync -a --delete \
+    -e "ssh -p ${SSH_PORT} -i ${SSH_KEY} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q" \
+    "${VAULT_PATH}/" \
+    "${SSH_USER}@${SSH_HOST}:${TARGET_DIR}/"
+
+echo "[$(date -Iseconds)] Vault sync complete."


### PR DESCRIPTION
## Summary

- **Secrets export**: Deploy `/etc/profile.d/openclaw-secrets.sh` that sources `secrets.env` with `set -a` (auto-export). Hook into `/etc/bash.bashrc` for non-login shells (`limactl shell`). `gh auth status` now works without manual export.
- **Vault sync**: Rsync vault from host into overlay upper dir over SSH during `sandbox up`. iCloud's `filecoordinationd` locks all files in `~/Library/Mobile Documents/` making them unreadable through virtiofs — even with Obsidian closed. The rsync bypass puts readable copies at `/workspace-obsidian/`.
- **Standalone script**: `scripts/sync-vault.sh` for manual or cron-based vault re-sync.

## Verified

```
$ limactl shell openclaw-sandbox -- gh auth status
✓ Logged in to github.com account Peleke (GH_TOKEN)

$ limactl shell openclaw-sandbox -- cat /workspace-obsidian/2026-02-03.md | head -3
# Daily Note - February 3, 2026
## Morning Standup
**Energy:** 6/10

$ ./scripts/sync-vault.sh
[2026-02-07T21:40:33-05:00] Vault sync complete.
```

## Test plan

- [x] 215 CLI tests pass (7 new vault sync tests)
- [x] Full reprovision on running VM
- [x] `gh auth status` works from `limactl shell` (no manual source/export)
- [x] Vault files readable at `/workspace-obsidian/` while Obsidian is open on host
- [x] `scripts/sync-vault.sh` standalone sync works

🤖 Generated with [Claude Code](https://claude.com/claude-code)