### PR TITLE
fix(sandbox): vault write access for Obsidian workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ OpenClaw's built-in sandbox containerizes tool executions inside the VM. Every s
 `gh` installed from the official APT repository. `GH_TOKEN` passthrough from secrets — no `gh auth login` needed. Available both in the VM and inside sandbox containers.
 
 ### 📓 Obsidian Vault Access
-Mount your vault read-only into the VM and sandbox containers. The agent can read your notes but can't modify them. `OBSIDIAN_VAULT_PATH` is exported so agents know where to find vault files.
+Mount your vault into the VM at `/workspace-obsidian` via OverlayFS. Writes from sandbox containers land in the overlay upper layer, not on the host vault directly — the sync gate controls when changes propagate back. `OBSIDIAN_VAULT_PATH` is exported so agents know where to find vault files.
 
 ### 📡 Telegram Integration
 Pairing-based access control. Pre-seed your Telegram user ID or use the built-in pairing flow. No open access by default.

--- a/ansible/roles/sandbox/defaults/main.yml
+++ b/ansible/roles/sandbox/defaults/main.yml
@@ -55,4 +55,4 @@ sandbox_setup_script: "scripts/sandbox-setup.sh"
 
 # Obsidian vault bind mount for sandbox containers
 sandbox_vault_path: "/workspace-obsidian"
-sandbox_vault_access: "ro"
+sandbox_vault_access: "rw"

--- a/docs/architecture/defense-in-depth.md
+++ b/docs/architecture/defense-in-depth.md
@@ -37,7 +37,7 @@ Individual tool executions -- file reads, shell commands, browser actions -- are
 
 **Workspace bind mount.** The container gets `/workspace` bind-mounted read-write, which is the overlay merged view (not the host mount). Writes from inside the container go to the overlay upper layer.
 
-**Read-only vault access.** If an Obsidian vault is mounted, it is bind-mounted into containers as read-only (`/workspace-obsidian:/workspace-obsidian:ro`).
+**Overlay-protected vault access.** If an Obsidian vault is mounted, it is bind-mounted into containers as read-write (`/workspace-obsidian:/workspace-obsidian:rw`). Writes land in the overlay upper layer, not on the host vault directly. The sync gate controls when changes propagate back.
 
 ## The Gated Exit Path
 

--- a/docs/configuration/docker-sandbox.md
+++ b/docs/configuration/docker-sandbox.md
@@ -174,7 +174,7 @@ This sets `docker_enabled=false`, which skips both the Docker CE installation an
 | `sandbox_docker_network` | `bridge` | `bridge`, `host`, `none` |
 | `sandbox_setup_script` | `scripts/sandbox-setup.sh` | Build script relative to workspace |
 | `sandbox_vault_path` | `/workspace-obsidian` | Vault bind mount source |
-| `sandbox_vault_access` | `ro` | Vault access in container: `ro`, `rw` |
+| `sandbox_vault_access` | `rw` | Vault access in container: `ro`, `rw` |
 
 Override any of these with `-e`:
 

--- a/docs/configuration/obsidian-vault.md
+++ b/docs/configuration/obsidian-vault.md
@@ -61,10 +61,10 @@ The sandbox role automatically adds a read-only bind mount into Docker container
 }
 ```
 
-!!! note "Read-only by default"
-    The vault is mounted as `ro` (read-only) in containers. This is controlled by the `sandbox_vault_access` variable, which defaults to `ro`. Change it with:
+!!! note "Overlay-protected writes"
+    The vault is mounted as `rw` (read-write) in containers. Writes land in the overlay upper layer, not directly on the host vault. The sync gate controls when changes propagate back. To lock the vault to read-only, override with:
     ```bash
-    -e "sandbox_vault_access=rw"
+    -e "sandbox_vault_access=ro"
     ```
 
 ## Stale Mount Cleanup
@@ -84,7 +84,7 @@ This prevents systemd failures from mount units pointing to nonexistent lower di
 | `overlay_lower_obsidian` | `/mnt/obsidian` | Host vault mount point |
 | `overlay_obsidian_path` | `/workspace-obsidian` | Merged overlay mount point |
 | `sandbox_vault_path` | `/workspace-obsidian` | Source path for container bind mount |
-| `sandbox_vault_access` | `ro` | Container access: `ro` or `rw` |
+| `sandbox_vault_access` | `rw` | Container access: `ro` or `rw` |
 
 ## Verification Commands
 

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -68,7 +68,7 @@ Configuration flows through three layers:
 | `sandbox_docker_network` | `bridge` | `openclaw.json` | Network: `bridge`, `host`, `none` | `-e` |
 | `sandbox_setup_script` | `scripts/sandbox-setup.sh` | -- | Build script location | `-e` |
 | `sandbox_vault_path` | `/workspace-obsidian` | `openclaw.json` | Vault bind mount source | `-e` |
-| `sandbox_vault_access` | `ro` | `openclaw.json` | Vault access: `ro`, `rw` | `-e` |
+| `sandbox_vault_access` | `rw` | `openclaw.json` | Vault access: `ro`, `rw` | `-e` |
 
 ### Docker Role (`ansible/roles/docker/defaults/main.yml`)
 

--- a/tests/obsidian/test-obsidian-ansible.sh
+++ b/tests/obsidian/test-obsidian-ansible.sh
@@ -125,10 +125,10 @@ else
   log_fail "Missing default: sandbox_vault_access"
 fi
 
-if grep -q '"ro"' "$SANDBOX_DEFAULTS"; then
-  log_pass "sandbox_vault_access defaults to ro (read-only)"
+if grep -q '"rw"' "$SANDBOX_DEFAULTS"; then
+  log_pass "sandbox_vault_access defaults to rw (read-write, overlay-protected)"
 else
-  log_fail "sandbox_vault_access should default to ro"
+  log_fail "sandbox_vault_access should default to rw"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- Change `sandbox_vault_access` default from `ro` to `rw` so agents can write to the Obsidian vault inside sandbox containers
- The overlay upper layer already protects the host vault — writes land in the overlay, not on the host directly; sync gate controls propagation
- Update tests (34/34 pass) and all docs referencing the old `ro` default

## Test plan
- [x] `tests/obsidian/test-obsidian-ansible.sh` — 34/34 pass
- [x] Verified live in VM: agent can now write to `/workspace-obsidian`
- [ ] Reprovision from scratch confirms new default lands in `openclaw.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)