### PR TITLE
feat(cadence): wire end-to-end signals — vault sync, skills mount, file-log, launchd

### DIFF
--- a/ansible/roles/cadence/defaults/main.yml
+++ b/ansible/roles/cadence/defaults/main.yml
@@ -6,7 +6,7 @@
 cadence_enabled: false
 
 # Vault path inside VM (mounted from host)
-cadence_vault_path: "/mnt/obsidian"
+cadence_vault_path: "/workspace-obsidian"
 
 # Delivery channel: telegram, discord, log
 cadence_delivery_channel: "telegram"

--- a/ansible/roles/cadence/templates/cadence.json.j2
+++ b/ansible/roles/cadence/templates/cadence.json.j2
@@ -3,8 +3,8 @@
   "vaultPath": "{{ cadence_vault_path }}",
   "delivery": {
     "channel": "{{ cadence_delivery_channel }}"{% if cadence_telegram_chat_id %},
-    "telegramChatId": "{{ cadence_telegram_chat_id }}"{% endif %}
-
+    "telegramChatId": "{{ cadence_telegram_chat_id }}"{% endif %},
+    "fileLogPath": "{{ user_home }}/.openclaw/cadence/signals.jsonl"
   },
   "pillars": {{ cadence_pillars | to_json }},
   "llm": {

--- a/cli/src/sandbox_cli/orchestrator.py
+++ b/cli/src/sandbox_cli/orchestrator.py
@@ -137,7 +137,10 @@ def _sync_vault(
         console.print(f"[yellow]Vault path does not exist: {vault_path}[/yellow]")
         return
 
-    target = "/var/lib/openclaw/overlay/obsidian/upper/"
+    # Write to the merged overlay mount so inotify fires and file watchers
+    # (chokidar/cadence) see the changes.  Writing directly to the raw upper
+    # dir bypasses inotify on the merged mount.
+    target = "/workspace-obsidian/"
     console.print("[blue]Syncing Obsidian vault into VM overlay...[/blue]")
     console.print(f"  Source: {vault_path} (host)")
     console.print(f"  Target: {target} (VM)")
@@ -148,7 +151,7 @@ def _sync_vault(
     )
     result = subprocess.run(
         [
-            "rsync", "-a", "--delete",
+            "rsync", "-a", "--delete", "--exclude=.obsidian/",
             "-e", ssh_cmd,
             f"{vault_path}/",
             f"{ssh.user}@{ssh.host}:{target}",

--- a/cli/tests/test_orchestrator.py
+++ b/cli/tests/test_orchestrator.py
@@ -235,7 +235,8 @@ class TestSyncVault:
         assert "-a" in args
         assert "--delete" in args
         assert f"{vault_dir}/" in args
-        assert "test@127.0.0.1:/var/lib/openclaw/overlay/obsidian/upper/" in args
+        assert "test@127.0.0.1:/workspace-obsidian/" in args
+        assert "--exclude=.obsidian/" in args
 
     def test_sync_uses_ssh_details(self, vault_profile, vault_dir, ssh):
         with patch("sandbox_cli.orchestrator.subprocess.run") as mock_run:

--- a/scripts/com.openclaw.cadence.plist
+++ b/scripts/com.openclaw.cadence.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.openclaw.cadence</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/peleke/Documents/Projects/openclaw/scripts/cadence-start.sh</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/cadence.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/cadence.log</string>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/peleke/Documents/Projects/openclaw</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/peleke/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>/Users/peleke</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/com.openclaw.vault-sync.plist
+++ b/scripts/com.openclaw.vault-sync.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.openclaw.vault-sync</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/peleke/Documents/Projects/openclaw-sandbox/scripts/sync-vault.sh</string>
+    </array>
+
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/vault-sync.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/vault-sync.log</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/sync-skills.sh
+++ b/scripts/sync-skills.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# sync-skills.sh - Sync custom skills from host into VM
+#
+# Usage: ./scripts/sync-skills.sh
+
+set -euo pipefail
+
+VM_NAME="openclaw-sandbox"
+SKILLS_SRC="/Users/peleke/Documents/Projects/skills/skills/custom"
+TARGET_DIR="$(limactl shell "$VM_NAME" -- bash -c 'echo $HOME' 2>/dev/null | tr -d '\r')/.openclaw/skills-extra"
+
+# Verify source exists
+if [[ ! -d "$SKILLS_SRC" ]]; then
+    echo "ERROR: Skills source does not exist: $SKILLS_SRC"
+    exit 1
+fi
+
+# Verify VM is running
+if ! limactl list --json 2>/dev/null | python3 -c "
+import json, sys
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    obj = json.loads(line)
+    if obj.get('name') == '${VM_NAME}' and obj.get('status') == 'Running':
+        sys.exit(0)
+sys.exit(1)
+" 2>/dev/null; then
+    echo "ERROR: VM '${VM_NAME}' is not running"
+    exit 1
+fi
+
+# Get SSH details
+SSH_CONFIG=$(limactl show-ssh --format=config "$VM_NAME" 2>/dev/null)
+SSH_HOST=$(echo "$SSH_CONFIG" | grep -m1 'Hostname ' | awk '{print $2}')
+SSH_PORT=$(echo "$SSH_CONFIG" | grep -m1 'Port ' | awk '{print $2}')
+SSH_USER=$(echo "$SSH_CONFIG" | grep -m1 'User ' | awk '{print $2}')
+SSH_KEY=$(echo "$SSH_CONFIG" | grep -m1 'IdentityFile ' | awk '{print $2}' | tr -d '"')
+
+# Ensure target directory exists
+ssh -p "${SSH_PORT}" -i "${SSH_KEY}" \
+    -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q \
+    "${SSH_USER}@${SSH_HOST}" "mkdir -p ${TARGET_DIR}"
+
+echo "[$(date -Iseconds)] Syncing skills: $SKILLS_SRC -> $VM_NAME:$TARGET_DIR"
+
+rsync -a --delete \
+    -e "ssh -p ${SSH_PORT} -i ${SSH_KEY} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q" \
+    "${SKILLS_SRC}/" \
+    "${SSH_USER}@${SSH_HOST}:${TARGET_DIR}/"
+
+echo "[$(date -Iseconds)] Skills sync complete."

--- a/scripts/sync-vault.sh
+++ b/scripts/sync-vault.sh
@@ -14,7 +14,10 @@
 set -euo pipefail
 
 VM_NAME="openclaw-sandbox"
-TARGET_DIR="/var/lib/openclaw/overlay/obsidian/upper"
+# Write to the merged overlay mount so inotify fires and chokidar picks it up.
+# Writing to the raw upper dir (/var/lib/openclaw/overlay/obsidian/upper)
+# bypasses inotify on the merged mount — cadence would never see the change.
+TARGET_DIR="/workspace-obsidian"
 
 # Resolve vault path: argument > profile > default
 if [[ -n "${1:-}" ]]; then
@@ -68,7 +71,7 @@ SSH_KEY=$(echo "$SSH_CONFIG" | grep -m1 'IdentityFile ' | awk '{print $2}' | tr 
 
 echo "[$(date -Iseconds)] Syncing vault: $VAULT_PATH -> $VM_NAME:$TARGET_DIR"
 
-rsync -a --delete \
+rsync -a --delete --exclude='.obsidian/' \
     -e "ssh -p ${SSH_PORT} -i ${SSH_KEY} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -q" \
     "${VAULT_PATH}/" \
     "${SSH_USER}@${SSH_HOST}:${TARGET_DIR}/"

--- a/tests/cadence/test-cadence-ansible.sh
+++ b/tests/cadence/test-cadence-ansible.sh
@@ -125,6 +125,13 @@ if [[ -f "$TEMPLATE_FILE" ]]; then
     fi
   done
 
+  # Check fileLogPath in delivery section
+  if grep -q "fileLogPath" "$TEMPLATE_FILE"; then
+    log_pass "Template includes fileLogPath for container bridging"
+  else
+    log_fail "Template missing fileLogPath in delivery section"
+  fi
+
   # Check JSON structure (basic brace matching)
   OPEN_BRACES=$(grep -o '{' "$TEMPLATE_FILE" | wc -l | tr -d ' ')
   CLOSE_BRACES=$(grep -o '}' "$TEMPLATE_FILE" | wc -l | tr -d ' ')
@@ -215,10 +222,10 @@ fi
 
 # Test: Vault path is VM path, not macOS
 VAULT_DEFAULT=$(grep "cadence_vault_path:" "$DEFAULTS_FILE" | sed 's/.*: *//' | tr -d '"')
-if [[ "$VAULT_DEFAULT" == /mnt/* ]]; then
+if [[ "$VAULT_DEFAULT" == /mnt/* || "$VAULT_DEFAULT" == /workspace* ]]; then
   log_pass "Default vault path is VM path: $VAULT_DEFAULT"
 elif [[ "$VAULT_DEFAULT" == /Users/* ]]; then
-  log_fail "Default vault path is macOS path (should be /mnt/...)"
+  log_fail "Default vault path is macOS path (should be /mnt/... or /workspace-...)"
 else
   log_info "Default vault path: $VAULT_DEFAULT"
 fi


### PR DESCRIPTION
## Summary

- Add vault sync launchd plist (`com.openclaw.vault-sync.plist`) — runs `sync-vault.sh` every 5 minutes on macOS host
- Add cadence launchd plist (`com.openclaw.cadence.plist`) — persistent `bun scripts/cadence.ts start` on macOS host
- Add skills sync script (`sync-skills.sh`) — rsync custom skills from host into VM via SSH
- Add `--skills PATH` flag to `bootstrap.sh` — Lima mount at `/mnt/skills-custom` (read-only, takes effect on VM recreate)
- Change `cadence_vault_path` default from `/mnt/obsidian` to `/workspace-obsidian` (reads from overlay, not raw virtiofs mount)
- Add `fileLogPath` to `cadence.json.j2` template — bridges Cadence signals to sandbox Docker containers via JSONL file
- Update cadence ansible lint tests for new vault path + fileLogPath assertions

## Test plan

- [x] Cadence ansible lint: 33/33 pass
- [x] CLI pytest suite: 273/273 pass
- [ ] VM E2E: reprovision with `sandbox up` and verify cadence.json has `fileLogPath` + `/workspace-obsidian` vault path
- [ ] Install launchd plists and verify vault sync runs every 5 minutes
- [ ] Run `sync-skills.sh` and verify skills appear in VM at `~/.openclaw/skills-extra/`

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)