### PR TITLE
docs: bring documentation current with PRs #36–#70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,69 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+**Cadence Wiring (PR #70)**
+- End-to-end vault sync pipeline: Obsidian note → rsync → chokidar → signal bus → Telegram
+- `--skills PATH` flag mounts custom skills directory at `/mnt/skills-custom` (read-only)
+- `fileLogPath` in cadence.json enables container signal bridging via JSONL
+- launchd plists for host-side scheduling (`com.openclaw.vault-sync.plist`, `com.openclaw.cadence.plist`)
+- `--exclude=.obsidian/` in rsync avoids ESTALE on virtiofs lower-layer config files
+
+**MCP Server (PR #65)**
+- Agent-driven sandbox management via FastMCP (`sandbox-mcp` console script)
+- Tools: `sandbox_up`, `sandbox_down`, `sandbox_status`, `sandbox_ssh`, `sandbox_sync`
+- Runs over stdio transport for seamless integration with LLM agents
+- Plain-function implementations for testability; registered via `mcp.tool(fn)`
+
+**Secrets Auto-Export + Vault Rsync (PR #63)**
+- iCloud lock bypass: rsync-based vault sync for files locked by iCloud Drive
+- Host-side `sync-vault.sh` script for manual or cron-based vault sync
+
+**Python CLI (PRs #60, #62)**
+- Typer-based CLI replacing bash bootstrap as the primary interface
+- Commands: `sandbox up`, `sandbox down`, `sandbox destroy`, `sandbox status`, `sandbox ssh`, `sandbox sync`, `sandbox dashboard`
+- Profile-based configuration via `~/.openclaw-sandbox/profiles/`
+- Interactive `sandbox init` wizard for profile creation
+
+**File Ownership Fix (PR #58)**
+- Agent identity persistence across VM restarts
+
+**Dogfood-Ready Sandbox (PR #57)**
+- Config/data isolation: `~/.openclaw/` config files copied (patchable), agent data symlinked to writable mount
+- `--agent-data PATH` mounts persistent agent data at `/mnt/openclaw-agents`
+- `--buildlog-data PATH` mounts persistent buildlog data at `/mnt/buildlog-data`
+- Qortex interop role: seed exchange directories, buildlog interop config, qortex CLI
+- `--memgraph` and `--memgraph-port` flags for Memgraph port forwarding
+
+**Dual-Container Network Isolation (PR #55)**
+- Per-tool network routing: two containers per scope (isolated + network)
+- `networkAllow`: tool-level routing (`web_fetch`, `web_search` → bridge container)
+- `networkExecAllow`: command-prefix routing (`gh` → bridge, others → air-gapped)
+- `networkDocker`: bridge container config (network mode, DNS)
+- Operator extension variables: `sandbox_network_allow_extra`, `sandbox_network_exec_allow_extra`
+- BRAVE_API_KEY added to full secrets pipeline
+
+**MkDocs Documentation (PR #41)**
+- Full documentation site with MkDocs Material theme
+- Architecture, configuration, security (STRIDE), development, and troubleshooting docs
+
+**Obsidian Vault Access (PR #37)**
+- Vault mounting with OverlayFS overlay at `/workspace-obsidian`
+- Stale mount unit cleanup when vault is removed
+
+**GitHub CLI Integration (PR #36)**
+- gh-cli Ansible role with APT repo installation
+- GH_TOKEN secrets pipeline integration and sandbox env passthrough
+
+### Fixed
+
+- Vault write access default changed from `ro` to `rw` (PR #67)
+- Vault sync writes to merged overlay mount (`/workspace-obsidian/`) instead of upper dir, fixing inotify visibility (PR #70)
+- Jinja2 operator precedence bug in networkExecAllow injection (PR #55)
+- Obsidian overlay mount bad unit file error: double backslash → single in YAML plain scalar (PR #36)
+- Obsidian mount failure when no vault mounted: stale unit cleanup (PR #37)
+
 ## [0.3.0] - 2026-02-03
 
 ### Added

--- a/docs/configuration/qortex.md
+++ b/docs/configuration/qortex.md
@@ -1,0 +1,154 @@
+# Qortex Interop
+
+[Qortex](https://github.com/Peleke/qortex) is a knowledge-graph-backed coordination layer for multi-agent workflows. The sandbox's qortex role sets up **seed exchange directories** and **buildlog interop** so agents running in the sandbox can emit and consume structured signals.
+
+## What It Does
+
+The qortex role creates directory structure for signal exchange and optionally installs the qortex CLI:
+
+1. **Seed exchange directories** — `~/.qortex/seeds/{pending,processed,failed}` for structured data handoff
+2. **Signals directory** — `~/.qortex/signals/` for projection output (JSONL logs)
+3. **Buildlog interop config** — `~/.buildlog/interop.yaml` linking buildlog to qortex's seed pipeline
+4. **CLI installation** — `qortex` command via `uv tool install`
+
+## Setup
+
+Qortex is enabled by default when the sandbox is provisioned. No extra flags are needed:
+
+```bash
+# Using the Python CLI (recommended)
+sandbox up
+
+# Using bootstrap.sh directly
+./bootstrap.sh --openclaw ~/Projects/openclaw
+```
+
+### With Memgraph (Graph Database)
+
+To enable Memgraph port forwarding for graph queries:
+
+```bash
+# Forward all Memgraph ports (7687, 3000, 7444)
+./bootstrap.sh --openclaw ~/Projects/openclaw --memgraph
+
+# Forward specific ports
+./bootstrap.sh --openclaw ~/Projects/openclaw \
+  --memgraph-port 7687 \
+  --memgraph-port 3000
+```
+
+| Port | Service |
+|------|---------|
+| 7687 | Bolt protocol (Cypher queries) |
+| 3000 | Memgraph Lab (web UI) |
+| 7444 | Monitoring |
+
+## Directory Structure
+
+After provisioning, the VM has:
+
+```
+~/.qortex/
+├── seeds/
+│   ├── pending/       # New seeds waiting for processing
+│   ├── processed/     # Successfully consumed seeds
+│   └── failed/        # Seeds that failed processing
+└── signals/
+    └── projections.jsonl   # Signal projection output
+
+~/.buildlog/
+└── interop.yaml       # Buildlog ↔ Qortex exchange config
+```
+
+All directories are created with mode `0750`.
+
+### Interop Configuration
+
+The `interop.yaml` file tells buildlog where to find qortex's seed pipeline:
+
+```yaml
+---
+sources:
+  - name: qortex
+    pending_dir: ~/.qortex/seeds/pending
+    processed_dir: ~/.qortex/seeds/processed
+    failed_dir: ~/.qortex/seeds/failed
+    signal_log: ~/.qortex/signals/projections.jsonl
+```
+
+This enables buildlog to:
+
+- Drop seeds into `pending/` for qortex to pick up
+- Read signal projections from `signals/projections.jsonl`
+- Track processing status via the `processed/` and `failed/` directories
+
+## Configuration Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `qortex_enabled` | `true` | Enable qortex directory setup and interop config |
+| `qortex_install` | `true` | Install qortex CLI via `uv tool install` |
+| `qortex_extras` | `""` | Pip extras for qortex (e.g. `"anthropic"` for LLM features) |
+
+Override with `-e`:
+
+```bash
+# Disable qortex entirely
+./bootstrap.sh --openclaw ~/Projects/openclaw -e "qortex_enabled=false"
+
+# Install with LLM extras
+./bootstrap.sh --openclaw ~/Projects/openclaw -e 'qortex_extras=anthropic'
+```
+
+## Standalone Use
+
+The qortex role guards `~/.buildlog` directory creation — if the buildlog role has already created it (e.g., as a Lima mount symlink), qortex skips that step. This means qortex works both:
+
+- **With buildlog** — interop.yaml is deployed into the existing `~/.buildlog/`
+- **Without buildlog** — qortex creates `~/.buildlog/` as a real directory and deploys interop.yaml
+
+## Verification Commands
+
+```bash
+# Check seed directories exist
+limactl shell openclaw-sandbox -- ls -la ~/.qortex/seeds/
+
+# Check signals directory
+limactl shell openclaw-sandbox -- ls -la ~/.qortex/signals/
+
+# Check interop config
+limactl shell openclaw-sandbox -- cat ~/.buildlog/interop.yaml
+
+# Verify qortex CLI is installed
+limactl shell openclaw-sandbox -- qortex --version
+
+# Check uv tool list
+limactl shell openclaw-sandbox -- ~/.local/bin/uv tool list | grep qortex
+```
+
+## Troubleshooting
+
+### qortex CLI not found
+
+1. Check uv is installed: `limactl shell openclaw-sandbox -- ~/.local/bin/uv --version`
+2. Check tool list: `limactl shell openclaw-sandbox -- ~/.local/bin/uv tool list`
+3. Re-provision: `sandbox up` or `./bootstrap.sh --openclaw ~/Projects/openclaw`
+
+### interop.yaml missing
+
+The interop config is only deployed if it doesn't already exist (to preserve manual edits). To force re-creation:
+
+```bash
+limactl shell openclaw-sandbox -- rm ~/.buildlog/interop.yaml
+sandbox up  # or ./bootstrap.sh to re-provision
+```
+
+### Memgraph ports not forwarding
+
+1. Verify `--memgraph` or `--memgraph-port` was passed at VM creation time
+2. Lima port forwards are baked at creation — to change, delete and recreate:
+
+```bash
+sandbox destroy -f
+./bootstrap.sh --openclaw ~/Projects/openclaw --memgraph
+```

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -134,6 +134,7 @@ The bottom of `CHANGELOG.md` contains comparison links for each version. The rel
 
 | Version | Date | Milestone |
 |---------|------|-----------|
+| *Unreleased* | -- | PRs #36–#70: GitHub CLI, dual-container isolation, Python CLI, MCP server, config/data isolation, qortex interop, cadence wiring |
 | 0.3.0 | 2026-02-03 | S1-S7: Bootstrap through Cadence |
 | 0.2.0 | 2026-02-02 | S4-S6: Tailscale, Secrets, Telegram |
 | 0.1.0 | 2026-02-01 | S1: Initial bootstrap infrastructure |

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -54,7 +54,11 @@ Quick mode runs only the Ansible validation tests. This is fast (seconds) and us
 ./tests/sandbox/run-all.sh --quick && \
 ./tests/gh-cli/run-all.sh --quick && \
 ./tests/obsidian/run-all.sh --quick && \
-./tests/cadence/run-all.sh --quick
+./tests/cadence/run-all.sh --quick && \
+./tests/gateway/run-all.sh --quick && \
+./tests/buildlog/run-all.sh --quick && \
+./tests/qortex/run-all.sh --quick && \
+./tests/telegram/run-all.sh --quick
 ```
 
 !!! tip
@@ -66,7 +70,7 @@ Full mode runs both Ansible validation and VM deployment tests. The VM must be r
 
 ```bash
 # Ensure VM is up
-limactl list   # Should show openclaw-sandbox as Running
+sandbox status   # or: limactl list
 
 # Run full suite for a single role
 ./tests/overlay/run-all.sh
@@ -76,7 +80,11 @@ limactl list   # Should show openclaw-sandbox as Running
 ./tests/sandbox/run-all.sh && \
 ./tests/gh-cli/run-all.sh && \
 ./tests/obsidian/run-all.sh && \
-./tests/cadence/run-all.sh
+./tests/cadence/run-all.sh && \
+./tests/gateway/run-all.sh && \
+./tests/buildlog/run-all.sh && \
+./tests/qortex/run-all.sh && \
+./tests/telegram/run-all.sh
 ```
 
 !!! warning
@@ -147,6 +155,49 @@ Covers: `uv tool install buildlog`, CLAUDE.md 3-step pipeline (copy base, init-m
 | `test-telegram-role.sh` | VM deployment | Bot connection, pairing flow |
 
 Covers: `dmPolicy: "pairing"`, `TELEGRAM_BOT_TOKEN` secrets flow, pre-approved user ID.
+
+### Gateway Tests
+
+| File | Type | Description |
+|------|------|-------------|
+| `test-gateway-ansible.sh` | Ansible validation | Role structure, systemd unit, config injection |
+| `test-gateway-role.sh` | VM deployment | Gateway service running, port forwarding, Docker access |
+
+Covers: systemd service, `SupplementaryGroups=docker`, port 18789 forwarding, `openclaw.json` config.
+
+### Qortex Tests
+
+| File | Type | Description |
+|------|------|-------------|
+| `test-qortex-ansible.sh` | Ansible validation | Role structure, defaults, directory setup, interop config |
+| `test-qortex-role.sh` | VM deployment | Seed directories, signals directory, qortex CLI, interop.yaml |
+
+Covers: `~/.qortex/seeds/{pending,processed,failed}`, `~/.qortex/signals/`, `~/.buildlog/interop.yaml`, `uv tool install qortex`.
+
+### Python CLI Tests (pytest)
+
+The Python CLI has its own test suite (273 tests) run via pytest:
+
+```bash
+cd cli && pytest
+```
+
+Covers: profile management, VM orchestration, MCP server tools, Lima manager, config validation.
+
+## Test Counts Summary
+
+| Suite | Static (Ansible) | VM/E2E | Total |
+|-------|:-:|:-:|:-:|
+| Sandbox | 117 | 49 | 166 |
+| GitHub CLI | 110 | -- | 110 |
+| Cadence | 32 | 32 | 64 |
+| Overlay | 58 | 19 | 77 |
+| Obsidian | 66 | -- | 66 |
+| Qortex | 58 | -- | 58 |
+| Telegram | 56 | -- | 56 |
+| Gateway | 55 | -- | 55 |
+| Buildlog | 51 | -- | 51 |
+| Python CLI | -- | -- | 273 (pytest) |
 
 ## CI/CD
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
     - GitHub CLI: configuration/github-cli.md
     - Obsidian Vault: configuration/obsidian-vault.md
     - Cadence: configuration/cadence.md
+    - Qortex: configuration/qortex.md
     - buildlog: configuration/buildlog.md
   - Architecture:
     - Overview: architecture/overview.md


### PR DESCRIPTION
## Summary

- Brings all documentation current with PRs #36–#70 (dual-container isolation, Python CLI, MCP server, config/data isolation, qortex interop, cadence wiring)
- All user-facing pages now emphasize the **Python CLI** (`sandbox up`, `sandbox status`, etc.) as the primary interface
- Adds 1 new doc page, updates 9 existing files + mkdocs.yml nav

## Changes (11 files, +696/-52)

| File | What changed |
|------|-------------|
| `CHANGELOG.md` | Added [Unreleased] entries for PRs #36–#70 (Added + Fixed) |
| `docs/configuration/docker-sandbox.md` | Added dual-container network isolation section, updated flow diagram, config tables |
| `docs/configuration/qortex.md` | **New page** — qortex interop: seed dirs, interop config, CLI, memgraph flags |
| `docs/configuration/cadence.md` | Added fileLogPath, vault sync/inotify gotcha, --skills, launchd plists |
| `docs/configuration/obsidian-vault.md` | Added iCloud rsync sync, inotify gotcha, vault rw default |
| `docs/usage/bootstrap-flags.md` | CLI note at top, --skills/--agent-data/--buildlog-data/--memgraph flags |
| `docs/architecture/overview.md` | Qortex in role table, MCP server, Python CLI, new virtiofs mounts |
| `docs/index.md` | Updated feature highlights, CLI-first quick start |
| `docs/development/testing.md` | Added qortex/gateway/CLI suites, test counts summary table |
| `docs/development/releases.md` | Added unreleased version to history |
| `mkdocs.yml` | Added Qortex nav entry |

## Test plan

- [ ] Verify CHANGELOG entries match merged PRs (`gh pr list --state merged`)
- [ ] Verify mkdocs builds: `mkdocs serve` and check rendered pages
- [ ] Spot-check internal links resolve (no broken refs)
- [ ] Verify qortex.md appears in nav sidebar

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)