### PR TITLE
feat(cli): publish as bilrost on PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,113 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+  # Allow manual trigger for testing
+  workflow_dispatch:
+    inputs:
+      publish_target:
+        description: "Publish target"
+        required: true
+        default: "testpypi"
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Build package
+        run: uv build cli/
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: cli/dist/
+
+  test-install:
+    name: Test installation
+    needs: build
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Install from wheel
+        run: |
+          uv venv --python ${{ matrix.python-version }}
+          source .venv/bin/activate
+          uv pip install dist/*.whl
+
+      - name: Verify entry points
+        run: |
+          source .venv/bin/activate
+          bilrost --help
+          bilrost-mcp --help
+          sandbox --help
+          sandbox-mcp --help
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: [build, test-install]
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.publish_target == 'testpypi'
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [build, test-install]
+    if: >-
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' &&
+       github.event.inputs.publish_target == 'pypi')
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/cli/LICENSE
+++ b/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 Peleke Sengstacke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,80 @@
+# bilrost
+
+**Hardened Lima VM for running AI agents** — overlay isolation, network containment, secrets management, and gated sync.
+
+## Install
+
+```bash
+# Via pipx (recommended)
+pipx install bilrost
+
+# Via uv
+uv tool install bilrost
+
+# Via pip
+pip install bilrost
+```
+
+## Usage
+
+```bash
+# Interactive setup
+bilrost init
+
+# Provision the VM (~5 min first run)
+bilrost up
+
+# Check status
+bilrost status
+
+# SSH into the VM
+bilrost ssh
+
+# Sync overlay changes to host (with secret scanning)
+bilrost sync
+
+# Stop / destroy
+bilrost down
+bilrost destroy
+```
+
+## MCP Server
+
+Agents can manage the sandbox programmatically via FastMCP:
+
+```json
+{
+  "mcpServers": {
+    "sandbox": {
+      "command": "bilrost-mcp"
+    }
+  }
+}
+```
+
+9 tools: `sandbox_status`, `sandbox_up`, `sandbox_down`, `sandbox_destroy`, `sandbox_exec`, `sandbox_validate`, `sandbox_ssh_info`, `sandbox_gateway_info`, `sandbox_agent_identity`.
+
+## What It Does
+
+- **OverlayFS isolation** — host code mounted read-only, all writes contained in VM overlay
+- **Network containment** — UFW firewall with explicit allowlist (HTTPS, DNS, Tailscale, NTP only)
+- **Secrets management** — three injection methods, `0600` perms, never in process lists
+- **Gated sync** — gitleaks scanning + path allowlist before changes reach your host
+- **Docker sandboxing** — per-session containers with configurable network isolation
+- **12 Ansible roles** — overlay, secrets, gateway, docker, firewall, sync-gate, gh-cli, buildlog, cadence, qortex, tailscale, and more
+
+## Requirements
+
+- macOS (Apple Silicon or Intel)
+- [Homebrew](https://brew.sh/)
+- ~10GB disk space
+
+Dependencies (Lima, Ansible, etc.) are installed automatically on first run.
+
+## Documentation
+
+Full docs: [peleke.github.io/openclaw-sandbox](https://peleke.github.io/openclaw-sandbox/)
+
+## License
+
+MIT

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -3,10 +3,29 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "sandbox-cli"
+name = "bilrost"
 version = "0.1.0"
-description = "Typer CLI wrapper for OpenClaw sandbox bootstrap"
+description = "Hardened Lima VM for running AI agents — overlay isolation, network containment, secrets management, and gated sync."
+readme = "README.md"
+license = "MIT"
 requires-python = ">=3.11"
+authors = [{ name = "Peleke Sengstacke" }]
+keywords = ["sandbox", "ai-agents", "lima", "vm", "security", "isolation"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: MacOS",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Security",
+    "Topic :: Software Development :: Testing",
+    "Topic :: System :: Emulators",
+]
 dependencies = [
     "typer>=0.12,<1",
     "pydantic>=2,<3",
@@ -20,12 +39,29 @@ dependencies = [
 [project.optional-dependencies]
 dev = ["pytest>=8,<9", "pyyaml>=6,<7"]
 
+[project.urls]
+Homepage = "https://github.com/Peleke/openclaw-sandbox"
+Documentation = "https://peleke.github.io/openclaw-sandbox/"
+Repository = "https://github.com/Peleke/openclaw-sandbox"
+Issues = "https://github.com/Peleke/openclaw-sandbox/issues"
+Changelog = "https://github.com/Peleke/openclaw-sandbox/blob/main/CHANGELOG.md"
+
 [project.scripts]
+bilrost = "sandbox_cli.app:app"
+bilrost-mcp = "sandbox_cli.mcp_server:main"
+# Keep legacy entry points for backward compat
 sandbox = "sandbox_cli.app:app"
 sandbox-mcp = "sandbox_cli.mcp_server:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/sandbox_cli"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/sandbox_cli/",
+    "README.md",
+    "LICENSE",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -73,6 +73,39 @@ wheels = [
 ]
 
 [[package]]
+name = "bilrost"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "fastmcp" },
+    { name = "jinja2" },
+    { name = "pydantic" },
+    { name = "rich" },
+    { name = "tomli-w" },
+    { name = "typer" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastmcp", specifier = ">=2,<3" },
+    { name = "jinja2", specifier = ">=3.1,<4" },
+    { name = "pydantic", specifier = ">=2,<3" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8,<9" },
+    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6,<7" },
+    { name = "rich", specifier = ">=13,<14" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2,<3" },
+    { name = "tomli-w", specifier = ">=1,<2" },
+    { name = "typer", specifier = ">=0.12,<1" },
+]
+provides-extras = ["dev"]
+
+[[package]]
 name = "cachetools"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1487,39 +1520,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
 ]
-
-[[package]]
-name = "sandbox-cli"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "fastmcp" },
-    { name = "jinja2" },
-    { name = "pydantic" },
-    { name = "rich" },
-    { name = "tomli-w" },
-    { name = "typer" },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pyyaml" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "fastmcp", specifier = ">=2,<3" },
-    { name = "jinja2", specifier = ">=3.1,<4" },
-    { name = "pydantic", specifier = ">=2,<3" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8,<9" },
-    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6,<7" },
-    { name = "rich", specifier = ">=13,<14" },
-    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2,<3" },
-    { name = "tomli-w", specifier = ">=1,<2" },
-    { name = "typer", specifier = ">=0.12,<1" },
-]
-provides-extras = ["dev"]
 
 [[package]]
 name = "secretstorage"


### PR DESCRIPTION
## Summary
- Rename package from `sandbox-cli` → `bilrost` for PyPI publication
- Add `bilrost` + `bilrost-mcp` entry points (legacy `sandbox`/`sandbox-mcp` kept for backward compat)
- Add `.github/workflows/publish.yml` — trusted publishing (OIDC), build + install test matrix (3.11/3.12/3.13), publishes on GitHub release
- Add MIT LICENSE and PyPI-facing README for `cli/`
- GitHub environments `pypi` and `testpypi` created

## Install (after publish)
```bash
pipx install bilrost
# or
uv tool install bilrost
```

## Test plan
- [x] `uv build cli/` produces `bilrost-0.1.0-py3-none-any.whl`
- [x] All 4 entry points work (`bilrost`, `bilrost-mcp`, `sandbox`, `sandbox-mcp`)
- [x] 296 pytest tests pass
- [ ] Publish workflow triggers on release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)