### PR TITLE
docs: rebrand to Bilrost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to openclaw-sandbox are documented here.
+All notable changes to Bilrost (formerly openclaw-sandbox) are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `--exclude=.obsidian/` in rsync avoids ESTALE on virtiofs lower-layer config files
 
 **MCP Server (PR #65)**
-- Agent-driven sandbox management via FastMCP (`sandbox-mcp` console script)
+- Agent-driven sandbox management via FastMCP (`bilrost-mcp` console script)
 - Tools: `sandbox_up`, `sandbox_down`, `sandbox_status`, `sandbox_ssh`, `sandbox_sync`
 - Runs over stdio transport for seamless integration with LLM agents
 - Plain-function implementations for testability; registered via `mcp.tool(fn)`
@@ -28,9 +28,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Python CLI (PRs #60, #62)**
 - Typer-based CLI replacing bash bootstrap as the primary interface
-- Commands: `sandbox up`, `sandbox down`, `sandbox destroy`, `sandbox status`, `sandbox ssh`, `sandbox sync`, `sandbox dashboard`
-- Profile-based configuration via `~/.openclaw-sandbox/profiles/`
-- Interactive `sandbox init` wizard for profile creation
+- Commands: `bilrost up`, `bilrost down`, `bilrost destroy`, `bilrost status`, `bilrost ssh`, `bilrost sync`, `bilrost dashboard`
+- Profile-based configuration via `~/.openclaw/sandbox-profile.toml`
+- Interactive `bilrost init` wizard for profile creation
 
 **File Ownership Fix (PR #58)**
 - Agent identity persistence across VM restarts

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# OpenClaw Sandbox
+# Bilrost
 
 ### Secure, Isolated VM for Running AI Agents
 
@@ -30,22 +30,22 @@ You need the agent to do real work — access your code, call APIs, run tools �
 
 ## The Solution
 
-**OpenClaw Sandbox** runs agents inside a hardened Lima VM with strict network policies, OverlayFS filesystem isolation, and Docker-containerized tool execution. Your code is mounted read-only. All writes are contained in an overlay. Changes only reach your host through a validated sync gate with secret scanning.
+**Bilrost** runs agents inside a hardened Lima VM with strict network policies, OverlayFS filesystem isolation, and Docker-containerized tool execution. Your code is mounted read-only. All writes are contained in an overlay. Changes only reach your host through a validated sync gate with secret scanning.
 
 One command to provision. One command to tear down. Everything in between is contained.
 
 ```
-You: sandbox up
+You: bilrost up
      → Lima VM created (Ubuntu 24.04, Apple VZ)
      → Ansible provisions 10 roles (overlay, Docker, firewall, secrets, gateway...)
      → Gateway starts on :18789
      → Agent is running. You are safe.
 
-You: sandbox status
+You: bilrost status
      → VM: Running | Mode: secure | Overlay: active
-     → Agent: Claw (🦞) | Observations: 847
+     → Agent: Vindler (🦞) | Observations: 847
 
-You: sandbox ssh
+You: bilrost ssh
      → You're inside the VM. Do whatever you want.
 ```
 
@@ -65,7 +65,7 @@ UFW firewall with explicit allowlist — only HTTPS, DNS, Tailscale, and NTP are
 Three injection methods (direct, secrets file, config mount). Secrets land in `/etc/openclaw/secrets.env` with `0600` permissions, loaded via `EnvironmentFile=` — never in process lists, never in logs. All Ansible tasks use `no_log: true`.
 
 ### 📂 Gated Sync
-Changes only reach your host through `sandbox sync`, which runs gitleaks secret scanning, path allowlisting, and size/filetype checks. In secure mode, you approve every change. In YOLO mode, it auto-syncs every 30 seconds.
+Changes only reach your host through `bilrost sync`, which runs gitleaks secret scanning, path allowlisting, and size/filetype checks. In secure mode, you approve every change. In YOLO mode, it auto-syncs every 30 seconds.
 
 ### 🐳 Docker Sandbox
 OpenClaw's built-in sandbox containerizes tool executions inside the VM. Every session gets its own container with bridge networking (configurable to `none` for full air-gap). The sandbox image is auto-augmented with `gh` if missing.
@@ -83,7 +83,7 @@ Pairing-based access control. Pre-seed your Telegram user ID or use the built-in
 [buildlog](https://github.com/Peleke/buildlog-template) is pre-installed for ambient learning capture — structured trajectories, Thompson Sampling for rule surfacing, automatic CLAUDE.md rendering. buildlog's own MCP server is registered with its full tool suite.
 
 ### ⚡ Zero-Config Deploy
-Single `sandbox up` from macOS. Homebrew, Lima, Ansible — all dependencies installed automatically. Apple Silicon with Rosetta, or Intel. ~10GB disk.
+Single `bilrost up` from macOS. Homebrew, Lima, Ansible — all dependencies installed automatically. Apple Silicon with Rosetta, or Intel. ~10GB disk.
 
 ---
 
@@ -104,29 +104,29 @@ Single `sandbox up` from macOS. Homebrew, Lima, Ansible — all dependencies ins
 
 ```bash
 # Install the CLI
-pip install openclaw-sandbox
-# or: uv pip install openclaw-sandbox
+pip install bilrost
+# or: pipx install bilrost / uv tool install bilrost
 
 # Interactive setup — creates ~/.openclaw/sandbox-profile.toml
-sandbox init
+bilrost init
 
 # Provision the VM (first run takes ~5 minutes)
-sandbox up
+bilrost up
 
 # Check status
-sandbox status
+bilrost status
 
 # SSH into the VM
-sandbox ssh
+bilrost ssh
 
 # Sync overlay changes to host (with secret scanning)
-sandbox sync
+bilrost sync
 
 # Stop the VM
-sandbox down
+bilrost down
 
 # Delete the VM entirely
-sandbox destroy
+bilrost destroy
 ```
 
 ### From Source
@@ -139,7 +139,7 @@ cd openclaw-sandbox
 uv pip install -e cli/
 
 # Provision
-sandbox up
+bilrost up
 ```
 
 ---
@@ -150,7 +150,7 @@ sandbox up
 ┌──────────────────────────────────────────────────────────┐
 │ macOS Host                                                │
 │                                                           │
-│  ~/Projects/openclaw ◄──── sandbox sync (approved only)  │
+│  ~/Projects/openclaw ◄──── bilrost sync (approved only)  │
 │                                                           │
 │  ╔════════════════════════════════════════════════════╗   │
 │  ║ Lima VM (Ubuntu 24.04)                             ║   │
@@ -202,23 +202,23 @@ Layer 2 (docker):    tool execution   → Docker container (bridge network)
 
 | Command | Description |
 |---------|-------------|
-| `sandbox init` | Interactive wizard — creates `~/.openclaw/sandbox-profile.toml` |
-| `sandbox up` | Provision (or reprovision) the VM |
-| `sandbox up --fresh` | Destroy + reprovision from scratch |
-| `sandbox down` | Stop the VM (force kill) |
-| `sandbox destroy` | Delete the VM entirely (with confirmation) |
-| `sandbox destroy -f` | Delete without confirmation |
-| `sandbox status` | Show VM state, profile summary, agent identity |
-| `sandbox ssh` | SSH into the VM (replaces process for TTY) |
-| `sandbox onboard` | Run the onboarding wizard inside the VM |
-| `sandbox sync` | Sync overlay changes to host (with validation) |
-| `sandbox sync --dry-run` | Preview sync without applying |
-| `sandbox dashboard` | Open the gateway dashboard |
-| `sandbox dashboard green` | Open a specific dashboard page |
+| `bilrost init` | Interactive wizard — creates `~/.openclaw/sandbox-profile.toml` |
+| `bilrost up` | Provision (or reprovision) the VM |
+| `bilrost up --fresh` | Destroy + reprovision from scratch |
+| `bilrost down` | Stop the VM (force kill) |
+| `bilrost destroy` | Delete the VM entirely (with confirmation) |
+| `bilrost destroy -f` | Delete without confirmation |
+| `bilrost status` | Show VM state, profile summary, agent identity |
+| `bilrost ssh` | SSH into the VM (replaces process for TTY) |
+| `bilrost onboard` | Run the onboarding wizard inside the VM |
+| `bilrost sync` | Sync overlay changes to host (with validation) |
+| `bilrost sync --dry-run` | Preview sync without applying |
+| `bilrost dashboard` | Open the gateway dashboard |
+| `bilrost dashboard green` | Open a specific dashboard page |
 
 ### Profile Configuration
 
-`sandbox init` creates `~/.openclaw/sandbox-profile.toml`:
+`bilrost init` creates `~/.openclaw/sandbox-profile.toml`:
 
 ```toml
 [mounts]
@@ -250,13 +250,13 @@ The MCP server lets agents manage the sandbox programmatically — no shell wrap
 
 ```bash
 # Install with MCP support
-pip install openclaw-sandbox
+pip install bilrost
 
 # Add to Claude Code settings (~/.claude/settings.json)
 {
   "mcpServers": {
-    "sandbox": {
-      "command": "sandbox-mcp"
+    "bilrost": {
+      "command": "bilrost-mcp"
     }
   }
 }
@@ -289,7 +289,7 @@ pip install openclaw-sandbox
 
 | Mode | Flag | Host Mounts | Overlay | Sync |
 |------|------|-------------|---------|------|
-| **Secure** (default) | _(none)_ | Read-only | Active | Manual via `sandbox sync` |
+| **Secure** (default) | _(none)_ | Read-only | Active | Manual via `bilrost sync` |
 | **YOLO** | `--yolo` | Read-only | Active | Auto-sync every 30s |
 | **YOLO-Unsafe** | `--yolo-unsafe` | Read-write | Disabled | Direct (legacy) |
 
@@ -313,7 +313,7 @@ Three ways to provide secrets, in priority order:
 
 ```bash
 # Via profile extra_vars or bootstrap.sh fallback
-sandbox up  # with extra_vars in profile
+bilrost up  # with extra_vars in profile
 ```
 
 ### 2. Secrets File (recommended for dev)
@@ -327,14 +327,14 @@ GH_TOKEN=ghp_xxx
 EOF
 
 # Point your profile at it
-sandbox init  # → secrets = "~/.openclaw-secrets.env"
+bilrost init  # → secrets = "~/.openclaw-secrets.env"
 ```
 
 ### 3. Config Mount (full OpenClaw config)
 
 ```bash
 # Point your profile at ~/.openclaw
-sandbox init  # → config = "~/.openclaw"
+bilrost init  # → config = "~/.openclaw"
 ```
 
 ### Supported Secrets
@@ -383,7 +383,7 @@ echo 'TELEGRAM_BOT_TOKEN=your-bot-token' >> ~/.openclaw-secrets.env
 # Pre-seed your Telegram user ID
 # Get it from @userinfobot on Telegram
 # Add to profile extra_vars: telegram_user_id = "YOUR_ID"
-sandbox up
+bilrost up
 ```
 
 Access control uses OpenClaw's pairing system (`dmPolicy: "pairing"`):
@@ -400,7 +400,7 @@ buildlog is pre-configured and the MCP server is registered. Claude Code has acc
 
 ```bash
 # Check state
-sandbox ssh
+bilrost ssh
 buildlog overview
 
 # Commit with logging
@@ -495,26 +495,26 @@ uv run --directory cli pytest tests/ -v
 
 ```bash
 # Check VM status
-sandbox status
+bilrost status
 
 # View gateway logs
-sandbox ssh
+bilrost ssh
 sudo journalctl -u openclaw-gateway -f
 
 # Check firewall rules
-sandbox ssh
+bilrost ssh
 sudo ufw status verbose
 
 # Verify secrets loaded
-sandbox ssh
+bilrost ssh
 sudo cat /etc/openclaw/secrets.env
 
 # Check overlay state
-sandbox ssh
+bilrost ssh
 overlay-status
 
 # Reset overlay (discard all writes)
-sandbox ssh
+bilrost ssh
 sudo overlay-reset
 ```
 

--- a/docs/architecture/defense-in-depth.md
+++ b/docs/architecture/defense-in-depth.md
@@ -1,6 +1,6 @@
 # Defense in Depth
 
-OpenClaw Sandbox uses two layers of isolation that work together. Neither layer alone is sufficient -- the point is that compromising one layer does not give an attacker (or a misbehaving agent) access to your host filesystem or credentials.
+Bilrost uses two layers of isolation that work together. Neither layer alone is sufficient -- the point is that compromising one layer does not give an attacker (or a misbehaving agent) access to your host filesystem or credentials.
 
 ![Defense in Depth](../diagrams/defense-in-depth.svg)
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-OpenClaw Sandbox runs AI agents inside a hardened Linux VM with strict filesystem isolation, network containment, and secure secrets handling. The architecture uses three nested layers -- macOS host, Lima VM, and Docker containers -- each adding a boundary between the agent and your data.
+Bilrost runs AI agents inside a hardened Linux VM with strict filesystem isolation, network containment, and secure secrets handling. The architecture uses three nested layers -- macOS host, Lima VM, and Docker containers -- each adding a boundary between the agent and your data.
 
 ![Architecture](../diagrams/architecture.svg)
 
@@ -8,7 +8,7 @@ OpenClaw Sandbox runs AI agents inside a hardened Linux VM with strict filesyste
 
 ### Layer 1: macOS Host
 
-The host machine runs the **Python CLI** (`sandbox` command) or `bootstrap.sh`, which orchestrates everything:
+The host machine runs the **Bilrost CLI** (`bilrost` command) or `bootstrap.sh`, which orchestrates everything:
 
 1. **Installs dependencies** from the Brewfile (Lima, Ansible, jq, gitleaks)
 2. **Generates a Lima YAML config** programmatically (no template file -- the config is built directly in bash with `cat` heredocs)
@@ -16,7 +16,7 @@ The host machine runs the **Python CLI** (`sandbox` command) or `bootstrap.sh`, 
 4. **Verifies host mounts** are accessible inside the VM
 5. **Runs the Ansible playbook** over SSH to provision all services
 
-The Python CLI (`sandbox up`, `sandbox status`, `sandbox ssh`, etc.) is the recommended interface. It wraps `bootstrap.sh` with profile-based configuration and an interactive setup wizard (`sandbox init`). An **MCP server** (`sandbox-mcp`) is also available for LLM agents to manage the sandbox programmatically via FastMCP over stdio.
+The Bilrost CLI (`bilrost up`, `bilrost status`, `bilrost ssh`, etc.) is the recommended interface. It wraps `bootstrap.sh` with profile-based configuration and an interactive setup wizard (`bilrost init`). An **MCP server** (`bilrost-mcp`) is also available for LLM agents to manage the sandbox programmatically via FastMCP over stdio.
 
 The host also provides the sync-gate exit path (`scripts/sync-gate.sh`) for getting approved changes back from the VM overlay.
 
@@ -158,7 +158,7 @@ This makes the gateway accessible at `localhost:18789` on the host. The `claw` C
 
 ## How Provisioning Works
 
-The Python CLI (`sandbox up`) is the recommended entry point. It loads a saved profile and calls `bootstrap.sh` under the hood. LLM agents can also use the MCP server (`sandbox-mcp`) which exposes `sandbox_up`, `sandbox_down`, `sandbox_status`, and other tools via FastMCP over stdio.
+The Bilrost CLI (`bilrost up`) is the recommended entry point. It loads a saved profile and calls `bootstrap.sh` under the hood. LLM agents can also use the MCP server (`bilrost-mcp`) which exposes `sandbox_up`, `sandbox_down`, `sandbox_status`, and other tools via FastMCP over stdio.
 
 The main flow in `bootstrap.sh`:
 

--- a/docs/configuration/cadence.md
+++ b/docs/configuration/cadence.md
@@ -30,8 +30,8 @@ Cadence requires:
 ### 1. Bootstrap with vault
 
 ```bash
-# Using the Python CLI (recommended) — configure vault path during `sandbox init`
-sandbox up
+# Using the Bilrost CLI (recommended) — configure vault path during `bilrost init`
+bilrost up
 
 # Using bootstrap.sh directly
 ./bootstrap.sh --openclaw ~/Projects/openclaw \

--- a/docs/configuration/dashboard-sync.md
+++ b/docs/configuration/dashboard-sync.md
@@ -58,18 +58,18 @@ script_path = ""
 
 ```bash
 # Run the sync
-sandbox dashboard sync
+bilrost dashboard sync
 
 # Preview without writing files
-sandbox dashboard sync --dry-run
+bilrost dashboard sync --dry-run
 ```
 
-The `sandbox dashboard` command (without `sync`) still opens the gateway dashboard in your browser, same as before. Use `--page` to jump to a specific page:
+The `bilrost dashboard` command (without `sync`) still opens the gateway dashboard in your browser, same as before. Use `--page` to jump to a specific page:
 
 ```bash
-sandbox dashboard              # open gateway dashboard
-sandbox dashboard --page green # open Green dashboard
-sandbox dashboard sync         # run GitHub-to-Obsidian sync
+bilrost dashboard              # open gateway dashboard
+bilrost dashboard --page green # open Green dashboard
+bilrost dashboard sync         # run GitHub-to-Obsidian sync
 ```
 
 ### MCP Tool

--- a/docs/configuration/docker-sandbox.md
+++ b/docs/configuration/docker-sandbox.md
@@ -112,7 +112,7 @@ Key fields:
 Operators can add extra tools or command prefixes to the network-routed lists without overriding the defaults:
 
 ```bash
-sandbox up  # after setting extra_vars in your profile, or:
+bilrost up  # after setting extra_vars in your profile, or:
 ./bootstrap.sh --openclaw ~/Projects/openclaw \
   -e '{"sandbox_network_allow_extra": ["mcp_fetch"]}' \
   -e '{"sandbox_network_exec_allow_extra": ["curl", "npm"]}'
@@ -130,7 +130,7 @@ These are merged with the base lists at provisioning time.
 To give all tools network access (single bridge container):
 
 ```bash
-sandbox up  # with extra_vars: sandbox_docker_network=bridge
+bilrost up  # with extra_vars: sandbox_docker_network=bridge
 # or
 ./bootstrap.sh --openclaw ~/Projects/openclaw -e "sandbox_docker_network=bridge"
 ```
@@ -149,7 +149,7 @@ For simpler configurations without per-tool routing, you can set a single networ
 ### Bridge
 
 ```bash
-sandbox up  # with extra_vars: sandbox_docker_network=bridge
+bilrost up  # with extra_vars: sandbox_docker_network=bridge
 # or
 ./bootstrap.sh --openclaw ~/Projects/openclaw -e "sandbox_docker_network=bridge"
 ```
@@ -159,7 +159,7 @@ Standard Docker networking. Containers get their own network namespace with NAT 
 ### None (maximum isolation)
 
 ```bash
-sandbox up  # with extra_vars: sandbox_docker_network=none
+bilrost up  # with extra_vars: sandbox_docker_network=none
 # or
 ./bootstrap.sh --openclaw ~/Projects/openclaw -e "sandbox_docker_network=none"
 ```
@@ -277,7 +277,7 @@ To run a lighter VM without Docker:
 
 ```bash
 # Using the Python CLI (recommended)
-sandbox up  # after running: sandbox init (and selecting --no-docker in profile)
+bilrost up  # after running: bilrost init (and selecting --no-docker in profile)
 
 # Using bootstrap.sh directly
 ./bootstrap.sh --openclaw ~/Projects/openclaw --no-docker

--- a/docs/configuration/obsidian-vault.md
+++ b/docs/configuration/obsidian-vault.md
@@ -7,8 +7,8 @@ The sandbox can mount an Obsidian vault from your host, giving agents access to 
 Pass the `--vault` flag when bootstrapping:
 
 ```bash
-# Using the Python CLI (recommended) — configure vault path during `sandbox init`
-sandbox up
+# Using the Bilrost CLI (recommended) — configure vault path during `bilrost init`
+bilrost up
 
 # Using bootstrap.sh directly
 ./bootstrap.sh --openclaw ~/Projects/openclaw --vault ~/Documents/Vaults/main

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -1,6 +1,6 @@
 # Configuration Overview
 
-Every configurable aspect of the OpenClaw Sandbox maps to an Ansible variable, a file on the VM, and a way to change it. This page is the single source of truth for what you can configure and how.
+Every configurable aspect of the Bilrost maps to an Ansible variable, a file on the VM, and a way to change it. This page is the single source of truth for what you can configure and how.
 
 ![Architecture](../diagrams/architecture.svg)
 

--- a/docs/configuration/qortex.md
+++ b/docs/configuration/qortex.md
@@ -16,8 +16,8 @@ The qortex role creates directory structure for signal exchange and optionally i
 Qortex is enabled by default when the sandbox is provisioned. No extra flags are needed:
 
 ```bash
-# Using the Python CLI (recommended)
-sandbox up
+# Using the Bilrost CLI (recommended)
+bilrost up
 
 # Using bootstrap.sh directly
 ./bootstrap.sh --openclaw ~/Projects/openclaw
@@ -132,7 +132,7 @@ limactl shell openclaw-sandbox -- ~/.local/bin/uv tool list | grep qortex
 
 1. Check uv is installed: `limactl shell openclaw-sandbox -- ~/.local/bin/uv --version`
 2. Check tool list: `limactl shell openclaw-sandbox -- ~/.local/bin/uv tool list`
-3. Re-provision: `sandbox up` or `./bootstrap.sh --openclaw ~/Projects/openclaw`
+3. Re-provision: `bilrost up` or `./bootstrap.sh --openclaw ~/Projects/openclaw`
 
 ### interop.yaml missing
 
@@ -140,7 +140,7 @@ The interop config is only deployed if it doesn't already exist (to preserve man
 
 ```bash
 limactl shell openclaw-sandbox -- rm ~/.buildlog/interop.yaml
-sandbox up  # or ./bootstrap.sh to re-provision
+bilrost up  # or ./bootstrap.sh to re-provision
 ```
 
 ### Memgraph ports not forwarding
@@ -149,6 +149,6 @@ sandbox up  # or ./bootstrap.sh to re-provision
 2. Lima port forwards are baked at creation — to change, delete and recreate:
 
 ```bash
-sandbox destroy -f
+bilrost destroy -f
 ./bootstrap.sh --openclaw ~/Projects/openclaw --memgraph
 ```

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Contributions to OpenClaw Sandbox are welcome. This guide covers the development workflow from fork to merged PR.
+Contributions to Bilrost are welcome. This guide covers the development workflow from fork to merged PR.
 
 ## Development Setup
 

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -1,6 +1,6 @@
 # Releases
 
-OpenClaw Sandbox uses [semantic versioning](https://semver.org/) with milestone-based releases.
+Bilrost uses [semantic versioning](https://semver.org/) with milestone-based releases.
 
 ## Versioning Policy
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-OpenClaw Sandbox has comprehensive test suites for every Ansible role. Tests are split into fast offline validation and full VM deployment checks.
+Bilrost has comprehensive test suites for every Ansible role. Tests are split into fast offline validation and full VM deployment checks.
 
 ## Test Structure
 
@@ -70,7 +70,7 @@ Full mode runs both Ansible validation and VM deployment tests. The VM must be r
 
 ```bash
 # Ensure VM is up
-sandbox status   # or: limactl list
+bilrost status   # or: limactl list
 
 # Run full suite for a single role
 ./tests/overlay/run-all.sh

--- a/docs/getting-started/first-session.md
+++ b/docs/getting-started/first-session.md
@@ -231,8 +231,8 @@ If you want a clean slate:
 | Delete VM | `./bootstrap.sh --delete` |
 | Re-provision | `./bootstrap.sh --openclaw ~/Projects/openclaw` |
 | Run onboard | `./bootstrap.sh --onboard` |
-| Dashboard sync | `sandbox dashboard sync` |
-| Dashboard sync (dry run) | `sandbox dashboard sync --dry-run` |
+| Dashboard sync | `bilrost dashboard sync` |
+| Dashboard sync (dry run) | `bilrost dashboard sync --dry-run` |
 
 ## Next Steps
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -60,7 +60,7 @@ If you want the agent to have read-only access to an Obsidian vault:
 Here is roughly what you will see:
 
 ```
-[INFO] OpenClaw Sandbox Bootstrap
+[INFO] Bilrost Bootstrap
 [INFO] ==========================
 
 [STEP] Generating Lima configuration...

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -1,12 +1,12 @@
 # Prerequisites
 
-Before you install OpenClaw Sandbox, make sure your machine meets a few basic requirements. The bootstrap script handles most of the heavy lifting, but it needs a couple of things to already be in place.
+Before you install Bilrost, make sure your machine meets a few basic requirements. The bootstrap script handles most of the heavy lifting, but it needs a couple of things to already be in place.
 
 ## System Requirements
 
 ### macOS
 
-OpenClaw Sandbox runs on **macOS only** -- it uses [Lima](https://lima-vm.io/) to manage a Linux VM via Apple's Virtualization framework. Both Apple Silicon (M1/M2/M3/M4) and Intel Macs are supported.
+Bilrost runs on **macOS only** -- it uses [Lima](https://lima-vm.io/) to manage a Linux VM via Apple's Virtualization framework. Both Apple Silicon (M1/M2/M3/M4) and Intel Macs are supported.
 
 !!! note
     On Apple Silicon, the VM uses Rosetta for x86_64 emulation automatically. You do not need to configure this yourself.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# OpenClaw Sandbox
+# Bilrost
 
-**Secure, isolated VM environment for running OpenClaw agents.**
+**Secure, isolated VM environment for running AI agents.**
 
 ---
 
@@ -17,7 +17,7 @@ You need a boundary between "what the agent can touch" and "everything else on y
 
 ## The Solution
 
-OpenClaw Sandbox runs your agents inside a **hardened Linux VM** (Ubuntu 24.04 on Lima) with strict network policies, layered filesystem isolation, and secure secrets handling. Everything provisions from a single command on macOS.
+Bilrost runs your agents inside a **hardened Linux VM** (Ubuntu 24.04 on Lima) with strict network policies, layered filesystem isolation, and secure secrets handling. Everything provisions from a single command on macOS.
 
 ```
 macOS Host
@@ -34,11 +34,11 @@ Changes only reach your host through a **validated sync gate** that runs gitleak
 
 | Feature | What it does |
 |---------|-------------|
-| [Python CLI](usage/bootstrap-flags.md) | `sandbox up`, `sandbox status`, `sandbox ssh` — profile-based management |
+| [Python CLI](usage/bootstrap-flags.md) | `bilrost up`, `bilrost status`, `bilrost ssh` — profile-based management |
 | [Dual-Container Isolation](configuration/docker-sandbox.md) | Per-tool network routing: air-gapped by default, bridge only for tools that need it |
 | [Filesystem Isolation](architecture/overlay-filesystem.md) | OverlayFS makes host mounts read-only; all writes land in an overlay layer |
 | [Network Containment](configuration/network-policy.md) | UFW firewall allows only HTTPS, DNS, and Tailscale; everything else is denied and logged |
-| [MCP Server](configuration/docker-sandbox.md) | LLM agents manage the sandbox via FastMCP (`sandbox-mcp`) |
+| [MCP Server](configuration/docker-sandbox.md) | LLM agents manage the sandbox via FastMCP (`bilrost-mcp`) |
 | [Secrets Management](configuration/secrets.md) | Multiple injection methods, file permissions at `0600`, never exposed in logs |
 | [Config/Data Isolation](configuration/obsidian-vault.md) | Config files copied (patchable), agent data symlinked to persistent mounts |
 | [Gated Sync](usage/sync-gate.md) | gitleaks scan + path allowlist before any changes reach the host |
@@ -52,24 +52,29 @@ Changes only reach your host through a **validated sync gate** that runs gitleak
 ## Quick Start
 
 ```bash
-# Clone the repository
-git clone https://github.com/Peleke/openclaw-sandbox.git
-cd openclaw-sandbox
-
-# Install the CLI
-pip install -e cli/
+# Install from PyPI
+pip install bilrost
+# or: pipx install bilrost / uv tool install bilrost
 
 # Create a profile interactively
-sandbox init
+bilrost init
 
 # Provision the VM
-sandbox up
+bilrost up
 
 # Check status
-sandbox status
+bilrost status
 
 # SSH into the VM
-sandbox ssh
+bilrost ssh
+```
+
+Or from source:
+
+```bash
+git clone https://github.com/Peleke/openclaw-sandbox.git
+cd openclaw-sandbox
+uv pip install -e cli/
 ```
 
 Or use `bootstrap.sh` directly:

--- a/docs/publication-series-outline.md
+++ b/docs/publication-series-outline.md
@@ -9,7 +9,7 @@
 
 ## Series Overview
 
-This publication series uses the OpenClaw Sandbox as a case study to teach practical threat modeling for AI agent systems. Each article focuses on one aspect of the STRIDE framework, adapted for the unique challenges of autonomous AI.
+This publication series uses the Bilrost as a case study to teach practical threat modeling for AI agent systems. Each article focuses on one aspect of the STRIDE framework, adapted for the unique challenges of autonomous AI.
 
 ### Why This Series?
 
@@ -65,7 +65,7 @@ gantt
    - Extensible for AI-specific concerns
    - Battle-tested by industry
 
-4. **Introducing the Case Study: OpenClaw Sandbox**
+4. **Introducing the Case Study: Bilrost**
    - What it is (Lima VM, Ansible, UFW)
    - Architecture overview
    - Why it exists (the problem it solves)
@@ -75,7 +75,7 @@ gantt
    - How to follow along
 
 ### Key Diagrams
-- Architecture diagram of OpenClaw Sandbox
+- Architecture diagram of Bilrost
 - Trust boundary visualization
 - STRIDE wheel with AI extensions
 
@@ -524,7 +524,7 @@ gantt
 
 1. **"Try It Yourself" Boxes**
    - Hands-on exercises for each threat category
-   - Use the actual OpenClaw Sandbox code
+   - Use the actual Bilrost code
 
 2. **Mermaid Diagrams**
    - Consistent visual style

--- a/docs/security/stride/elevation-of-privilege.md
+++ b/docs/security/stride/elevation-of-privilege.md
@@ -2,7 +2,7 @@
 
 We run arbitrary LLM-generated code inside a VM that has API keys, Docker access, and writable mounts back to the host. The question isn't whether there are privilege escalation paths -- it's how many layers an attacker has to punch through.
 
-This analysis enumerates the realistic escalation vectors for the OpenClaw Sandbox and is honest about which ones we've addressed and which ones remain open.
+This analysis enumerates the realistic escalation vectors for the Bilrost and is honest about which ones we've addressed and which ones remain open.
 
 ## Privilege Boundaries
 

--- a/docs/security/stride/supply-chain.md
+++ b/docs/security/stride/supply-chain.md
@@ -1,6 +1,6 @@
 # Supply Chain
 
-The OpenClaw Sandbox pulls code and binaries from npm, apt, Homebrew, NodeSource, the Bun installer, Docker Hub, and Ubuntu cloud images. Every one of these is a trust decision we're making implicitly. A compromised dependency runs with full privileges before any of our sandbox controls are active.
+The Bilrost pulls code and binaries from npm, apt, Homebrew, NodeSource, the Bun installer, Docker Hub, and Ubuntu cloud images. Every one of these is a trust decision we're making implicitly. A compromised dependency runs with full privileges before any of our sandbox controls are active.
 
 This is not a solvable problem -- it's a managed one. Here's what we actually do, what we don't, and what's worth doing for a hobby project.
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,6 +1,6 @@
 # Threat Model
 
-Yes, we know OpenClaw Sandbox is not enterprise-secure. It is a hobby project that runs AI agents inside a Lima VM. People love to point this out, as if we hadn't noticed.
+Yes, we know Bilrost is not enterprise-secure. It is a hobby project that runs AI agents inside a Lima VM. People love to point this out, as if we hadn't noticed.
 
 The reason we do threat modeling is not to posture about our "security posture." It is because we would rather think systematically about what could go wrong *before* we start bolting on security controls at random. A dumpster fire is still a dumpster fire, but at least we can map out where the flames are hottest.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-This page covers common issues, diagnostic commands, and recovery procedures for OpenClaw Sandbox.
+This page covers common issues, diagnostic commands, and recovery procedures for Bilrost.
 
 ---
 

--- a/docs/usage/bootstrap-flags.md
+++ b/docs/usage/bootstrap-flags.md
@@ -1,29 +1,29 @@
 # Bootstrap Flags
 
 !!! note "Python CLI is the recommended interface"
-    The primary way to manage your sandbox is now the **Python CLI** (`sandbox` command). The CLI wraps `bootstrap.sh` with a profile-based configuration system and interactive setup:
+    The primary way to manage your sandbox is now the **Bilrost CLI** (`bilrost` command, `pip install bilrost`). The CLI wraps `bootstrap.sh` with a profile-based configuration system and interactive setup:
 
     ```bash
     # Create a profile interactively
-    sandbox init
+    bilrost init
 
     # Provision or re-provision
-    sandbox up
+    bilrost up
 
     # Check status
-    sandbox status
+    bilrost status
 
     # SSH into the VM
-    sandbox ssh
+    bilrost ssh
 
     # Sync overlay changes to host
-    sandbox sync
+    bilrost sync
 
     # Stop the VM
-    sandbox down
+    bilrost down
 
     # Delete the VM
-    sandbox destroy
+    bilrost destroy
     ```
 
     See [Getting Started](../getting-started/first-session.md) for a walkthrough. The flags documented below still work with `bootstrap.sh` directly and are useful for understanding what the CLI does under the hood.
@@ -314,26 +314,26 @@ Running `bootstrap.sh` again on an existing VM skips creation and just re-runs t
 
 ## Full Examples
 
-### Using the Python CLI (recommended)
+### Using the Bilrost CLI (recommended)
 
 ```bash
 # Interactive profile setup — walks you through all options
-sandbox init
+bilrost init
 
 # Provision the VM with your saved profile
-sandbox up
+bilrost up
 
 # Re-provision after config changes
-sandbox up
+bilrost up
 
 # Check what's running
-sandbox status
+bilrost status
 
 # SSH into the VM
-sandbox ssh
+bilrost ssh
 
 # Sync overlay changes back to host
-sandbox sync
+bilrost sync
 ```
 
 ### Using bootstrap.sh directly

--- a/docs/usage/filesystem-modes.md
+++ b/docs/usage/filesystem-modes.md
@@ -1,6 +1,6 @@
 # Filesystem Modes
 
-OpenClaw Sandbox provides three filesystem modes that control how the agent interacts with your host files. The default is the most restrictive -- you opt into less isolation as needed.
+Bilrost provides three filesystem modes that control how the agent interacts with your host files. The default is the most restrictive -- you opt into less isolation as needed.
 
 ## How It Works
 
@@ -161,7 +161,7 @@ Lima mount writability is set at VM creation time. You can't switch to or from Y
 ```
 
 !!! note
-    This is a Lima limitation, not an OpenClaw Sandbox one. Virtiofs mount options are baked into the VM definition at creation time.
+    This is a Lima limitation, not a Bilrost one. Virtiofs mount options are baked into the VM definition at creation time.
 
 ## Obsidian Vault Overlay
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: OpenClaw Sandbox
-site_description: Secure, isolated VM environment for running OpenClaw agents
+site_name: Bilrost
+site_description: Secure, isolated VM environment for running AI agents
 site_url: https://peleke.github.io/openclaw-sandbox/
 repo_url: https://github.com/Peleke/openclaw-sandbox
 repo_name: Peleke/openclaw-sandbox


### PR DESCRIPTION
## Summary
- "OpenClaw Sandbox" → "Bilrost" in all prose, headings, and site name
- CLI commands: `sandbox` → `bilrost` in all code examples
- MCP entry point: `sandbox-mcp` → `bilrost-mcp` in setup docs
- Package install: `pip install openclaw-sandbox` → `pip install bilrost`
- 25 files touched across README, docs/, mkdocs.yml, CHANGELOG

GitHub URLs and internal references (VM name, docker image name) are unchanged.

## Test plan
- [x] No remaining "OpenClaw Sandbox" in any .md file
- [x] No remaining `pip install openclaw-sandbox` references
- [ ] Docs site builds (CI will verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)