### PR TITLE
fix(overlay): detect and remount stale workspace overlay

### DIFF
--- a/ansible/roles/overlay/tasks/main.yml
+++ b/ansible/roles/overlay/tasks/main.yml
@@ -144,6 +144,19 @@
         state: started
         daemon_reload: true
 
+    # Detect stale overlay (ESTALE from previous provision/reboot)
+    - name: Probe workspace overlay for stale handle
+      ansible.builtin.command: stat {{ overlay_workspace_path }}
+      register: overlay_probe
+      changed_when: false
+      failed_when: false
+
+    - name: Remount workspace overlay (stale handle detected)
+      when: overlay_probe.rc != 0
+      ansible.builtin.systemd:
+        name: workspace.mount
+        state: restarted
+
     - name: Enable and start obsidian overlay (if vault mounted)
       when: obsidian_mount_check.stat.exists
       ansible.builtin.systemd:


### PR DESCRIPTION
## Summary

- After `workspace.mount` starts, probe it with `stat`
- If the probe fails (ESTALE from previous provision/reboot), restart the mount unit to clear the stale handle
- Healthy mounts are untouched — no unnecessary remounts

Companion to #104 (gateway stat fallback). This fixes the root cause rather than working around it downstream.

## Test plan

- [ ] `bilrost up` on a VM with stale overlay — remount triggers, gateway installs succeed
- [ ] `bilrost up` on a healthy VM — no remount, idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)