### PR TITLE
fix: set user ownership on overlay upper directory

### DIFF
--- a/ansible/roles/overlay/tasks/main.yml
+++ b/ansible/roles/overlay/tasks/main.yml
@@ -30,6 +30,8 @@
       ansible.builtin.file:
         path: "{{ overlay_upper_base }}/openclaw/upper"
         state: directory
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
         mode: "0755"
 
     - name: Create overlay work directory (openclaw)


### PR DESCRIPTION
## Summary
- Overlay upper directory for openclaw was created as root:root (Ansible runs with `become: true`)
- `bun install` runs as the unprivileged user and needs write access to `/workspace`
- The obsidian overlay already had an ownership fix task but the openclaw one was missing
- Adds `owner`/`group: ansible_user` to match the obsidian pattern

## Root cause
`bilrost up --fresh` fails at `bun install` with:
```
EACCES: Permission denied: could not create the "node_modules" directory (mkdir)
```

## Test plan
- [ ] `bilrost up --fresh` completes without EACCES on bun install
- [ ] `/workspace/node_modules` is owned by the ansible user

🤖 Generated with [Claude Code](https://claude.com/claude-code)