### PR TITLE
fix: run overlay node_modules cleanup as unprivileged user

### DIFF
--- a/ansible/roles/gateway/tasks/main.yml
+++ b/ansible/roles/gateway/tasks/main.yml
@@ -224,12 +224,16 @@
 - name: Detect platform mismatch (reinstall if built on different platform)
   when: node_modules.stat.exists and not (linux_marker.stat.exists | default(false))
   block:
+    # Run cleanup as unprivileged user so OverlayFS whiteouts are user-owned.
+    # Root-owned whiteouts block unprivileged bun install from creating node_modules.
     - name: Clear existing node_modules (platform mismatch)
+      become: false
       ansible.builtin.file:
         path: "{{ workspace_path }}/node_modules"
         state: absent
 
     - name: Clear bun lockb (to force fresh install)
+      become: false
       ansible.builtin.file:
         path: "{{ workspace_path }}/bun.lockb"
         state: absent


### PR DESCRIPTION
## Summary
- Platform mismatch cleanup runs `state: absent` as root (inherits playbook `become: true`)
- On OverlayFS, deletion creates a whiteout character device owned by whoever ran the delete
- Root-owned whiteout blocks unprivileged `bun install` from creating `node_modules` (EACCES)
- Fix: `become: false` on cleanup tasks so whiteouts match the `bun install` user

## Root cause chain
1. `bilrost up --fresh` creates node_modules via macOS host mount (root in overlay upper)
2. Platform mismatch detected → delete as root → root-owned whiteout char device
3. `bun install` as peleke → EACCES on `mkdir node_modules`

Companion to #106 (overlay upper directory ownership).

🤖 Generated with [Claude Code](https://claude.com/claude-code)