### PR TITLE
docs: qortex MCP HTTP service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `--qortex-serve` flag on `bilrost up`
 - Environment file (`/etc/openclaw/qortex.env`) with vec backend, auth, Memgraph, and OTEL config
 
+**Qortex MCP HTTP Service**
+- New `qortex-mcp.service` systemd unit: runs `qortex mcp-serve --transport streamable-http` on port 8401
+- Dual-service architecture: REST API (`qortex.service`, port 8400) + MCP Streamable HTTP (`qortex-mcp.service`, port 8401)
+- Gateway connects via MCP Streamable HTTP instead of stdio subprocess pipes
+- Config injection: `http://localhost:8401/mcp` as baseUrl for `memorySearch.qortex` and `learning.qortex`
+- New Ansible defaults: `qortex_mcp_enabled`, `qortex_mcp_port`, `qortex_mcp_host`
+- `ansible_runner.py` passes `qortex_mcp_enabled` (tracks `qortex_serve_enabled`)
+
 **Extraction Config + Bilrost Upgrade (PR #99)**
 - `qortex_extraction` config variable for concept extraction strategy (`spacy`, `llm`, `none`)
 - `bilrost upgrade --dev` for installing latest dev builds from Test PyPI

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -93,11 +93,15 @@ The gateway is a Node.js process managed by systemd (`openclaw-gateway.service`)
 - Gets Docker access via `SupplementaryGroups=docker` (no re-login needed)
 - Depends on `workspace.mount` when overlay is active
 
-### Qortex HTTP Service (Optional)
+### Qortex Services (Optional)
 
-When `qortex_serve_enabled` is true, the qortex role deploys a persistent REST API server as a systemd service (`qortex.service`). This provides HTTP endpoints for vector search and knowledge graph queries, independent of the MCP server used by the gateway.
+When `qortex_serve_enabled` is true, the qortex role deploys two systemd services:
 
-The service supports API key authentication (auto-generated on first provision) and optional HMAC-SHA256 request signing. It can use either SQLite (default) or pgvector as its vector backend.
+- **`qortex.service`** (port 8400): REST API server for framework adapters (Agno, AutoGen, LangChain, etc.). Supports API key authentication (auto-generated on first provision) and optional HMAC-SHA256 request signing. Can use either SQLite (default) or pgvector as its vector backend.
+
+- **`qortex-mcp.service`** (port 8401): MCP Streamable HTTP server for gateway connections. The gateway connects here for memory search and learning pipeline operations via `StreamableHTTPClientTransport`. Uses FastMCP 3.x with the `streamable-http` transport, endpoint at `/mcp`. No authentication required (internal service).
+
+The MCP HTTP service replaces the previous stdio subprocess model, where the gateway spawned `qortex mcp-serve` as a child process for each connection.
 
 ### Database Services (Optional)
 

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -140,6 +140,9 @@ Configuration flows through three layers:
 | `qortex_pgvector_dsn` | `postgresql://qortex:qortex@localhost:5432/qortex` | `/etc/openclaw/qortex.env` | PostgreSQL connection string for pgvector | `-e` |
 | `qortex_api_keys` | `""` (auto-generated) | `/etc/openclaw/qortex.env` | API keys for HTTP service auth | `-e` |
 | `qortex_hmac_secret` | `""` | `/etc/openclaw/qortex.env` | HMAC-SHA256 shared secret | `-e` |
+| `qortex_mcp_enabled` | `false` | `/etc/systemd/system/qortex-mcp.service` | Enable qortex MCP HTTP service (Streamable HTTP for gateway) | `-e "qortex_mcp_enabled=true"` |
+| `qortex_mcp_port` | `8401` | `/etc/systemd/system/qortex-mcp.service` | MCP HTTP service listen port | `-e` |
+| `qortex_mcp_host` | `0.0.0.0` | `/etc/systemd/system/qortex-mcp.service` | MCP HTTP service bind address | `-e` |
 
 ### PgVector Role (`ansible/roles/pgvector/defaults/main.yml`)
 
@@ -229,6 +232,7 @@ The playbook executes roles in this order:
 | `/etc/openclaw/qortex-otel.env` | Qortex OTEL + Prometheus env (systemd EnvironmentFile) | qortex role |
 | `/etc/profile.d/qortex-otel.sh` | Qortex OTEL env for login/non-login shells | qortex role |
 | `/etc/systemd/system/qortex.service` | Qortex HTTP service unit (when `qortex_serve_enabled`) | qortex role |
+| `/etc/systemd/system/qortex-mcp.service` | Qortex MCP Streamable HTTP service (when `qortex_mcp_enabled`) | qortex role |
 | `/etc/openclaw/qortex.env` | Qortex HTTP service environment (vec backend, API keys) | qortex role |
 | `/etc/openclaw/qortex-api-key` | Auto-generated API key for qortex HTTP auth | qortex role |
 | `/opt/pgvector/docker-compose.yml` | PgVector Docker Compose config (when `pgvector_enabled`) | pgvector role |

--- a/docs/configuration/qortex.md
+++ b/docs/configuration/qortex.md
@@ -14,7 +14,8 @@ The qortex role handles nine things:
 6. **OTEL environment** (`/etc/openclaw/qortex-otel.env` + `/etc/profile.d/qortex-otel.sh`) so qortex exports traces and metrics to the host collector
 7. **Gateway config injection** (via `fix-vm-paths.yml`): injects `memorySearch` with `provider: "qortex"` and `learning` config into `openclaw.json` so the gateway uses qortex for both memory tools and bandit-based tool selection
 8. **HTTP service** (`qortex serve`): when `qortex_serve_enabled` is true, deploys a persistent REST API server as a systemd service with API key + HMAC-SHA256 authentication
-9. **PgVector integration**: when `qortex_vec_backend` is `pgvector`, the qortex HTTP service connects to the pgvector PostgreSQL container for vector search instead of the default SQLite backend
+9. **MCP HTTP service** (`qortex mcp-serve`): when `qortex_mcp_enabled` is true, deploys a second systemd service running the MCP server over Streamable HTTP transport, replacing the stdio subprocess model for gateway connections
+10. **PgVector integration**: when `qortex_vec_backend` is `pgvector`, the qortex HTTP service connects to the pgvector PostgreSQL container for vector search instead of the default SQLite backend
 
 ## Setup
 
@@ -162,6 +163,96 @@ limactl shell openclaw-sandbox -- bash -c \
    http://localhost:8400/health'
 ```
 
+## Qortex MCP HTTP Service
+
+When `qortex_mcp_enabled` is true (automatically tracks `qortex_serve_enabled`), the role deploys a second systemd service (`qortex-mcp.service`) that runs the qortex MCP server over Streamable HTTP transport. The gateway connects here for memory search and learning pipeline operations instead of spawning stdio subprocesses.
+
+### Why Two Services?
+
+The REST API (`qortex.service`, port 8400) serves framework adapters (Agno, AutoGen, LangChain) that speak standard HTTP with API key auth. The MCP service (`qortex-mcp.service`, port 8401) speaks the MCP Streamable HTTP protocol that the gateway's `StreamableHTTPClientTransport` expects. Separating them keeps auth and protocol concerns clean.
+
+### Enabling the MCP Service
+
+The MCP service is automatically enabled when the HTTP service is enabled:
+
+```bash
+# Using the Bilrost CLI
+bilrost up --qortex-serve
+
+# Using bootstrap.sh
+./bootstrap.sh --openclaw ~/Projects/openclaw -e "qortex_serve_enabled=true"
+```
+
+To enable MCP independently (uncommon):
+
+```bash
+./bootstrap.sh --openclaw ~/Projects/openclaw -e "qortex_mcp_enabled=true"
+```
+
+### Systemd Service
+
+The `qortex-mcp.service` unit:
+
+```ini
+[Unit]
+Description=Qortex MCP Server (Streamable HTTP)
+After=network-online.target qortex.service
+
+[Service]
+Type=simple
+Environment=FASTMCP_HOST=0.0.0.0
+Environment=FASTMCP_PORT=8401
+EnvironmentFile=-/etc/openclaw/qortex.env
+EnvironmentFile=-/etc/openclaw/qortex-otel.env
+ExecStart=~/.local/bin/qortex mcp-serve --transport streamable-http
+```
+
+FastMCP reads `FASTMCP_HOST` and `FASTMCP_PORT` via pydantic `BaseSettings` (env prefix `FASTMCP_`). The Streamable HTTP endpoint is served at `/mcp` (e.g., `http://localhost:8401/mcp`).
+
+### Gateway Config Injection
+
+When the MCP HTTP service is enabled, the gateway role's `fix-vm-paths.yml` switches `memorySearch` and `learning` config from stdio transport to HTTP transport:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "memorySearch": {
+        "qortex": {
+          "transport": "http",
+          "http": { "baseUrl": "http://localhost:8401/mcp" }
+        }
+      }
+    }
+  },
+  "learning": {
+    "qortex": {
+      "transport": "http",
+      "http": { "baseUrl": "http://localhost:8401/mcp" }
+    }
+  }
+}
+```
+
+No authentication is needed on the MCP endpoint — it is an internal service within the VM.
+
+### MCP Service Verification
+
+```bash
+# Check qortex MCP service is running
+limactl shell openclaw-sandbox -- systemctl status qortex-mcp
+
+# Check the MCP endpoint responds
+limactl shell openclaw-sandbox -- curl -s http://localhost:8401/mcp
+
+# Check both services are running
+limactl shell openclaw-sandbox -- systemctl status qortex qortex-mcp
+
+# Check the gateway sees HTTP transport
+limactl shell openclaw-sandbox -- bash -c \
+  'jq ".agents.defaults.memorySearch.qortex" ~/.openclaw/openclaw.json'
+```
+
 ## Directory Structure
 
 After provisioning, the VM has:
@@ -221,6 +312,9 @@ This enables buildlog to:
 | `qortex_pgvector_dsn` | `postgresql://qortex:qortex@localhost:5432/qortex` | PostgreSQL connection string for pgvector backend |
 | `qortex_api_keys` | `""` (auto-generated on first provision) | Comma-separated API keys for HTTP service auth |
 | `qortex_hmac_secret` | `""` | Shared secret for HMAC-SHA256 request signing |
+| `qortex_mcp_enabled` | `false` | Enable qortex MCP HTTP service (Streamable HTTP transport for gateway) |
+| `qortex_mcp_port` | `8401` | MCP HTTP service listen port |
+| `qortex_mcp_host` | `0.0.0.0` | MCP HTTP service bind address |
 | `qortex_wheel_dir` | `""` | Path to pre-built wheels directory (empty = install from PyPI) |
 
 Override with `-e`:
@@ -417,6 +511,14 @@ bilrost destroy -f
 3. Verify the environment file: `limactl shell openclaw-sandbox -- sudo cat /etc/openclaw/qortex.env`
 4. Verify the API key file exists: `limactl shell openclaw-sandbox -- sudo ls -la /etc/openclaw/qortex-api-key`
 5. Ensure the `server` extra was installed: `limactl shell openclaw-sandbox -- qortex serve --help`
+
+### Qortex MCP service not starting
+
+1. Check the service status: `limactl shell openclaw-sandbox -- systemctl status qortex-mcp`
+2. Check the journal: `limactl shell openclaw-sandbox -- journalctl -u qortex-mcp --no-pager -n 50`
+3. Verify FastMCP is installed: `limactl shell openclaw-sandbox -- qortex mcp-serve --help`
+4. Test the endpoint manually: `limactl shell openclaw-sandbox -- curl -s http://localhost:8401/mcp`
+5. Verify the gateway config has HTTP transport: `limactl shell openclaw-sandbox -- bash -c 'jq ".agents.defaults.memorySearch.qortex.transport" ~/.openclaw/openclaw.json'`
 
 ### PgVector container not running
 


### PR DESCRIPTION
## Summary
- Document dual-service architecture: REST API (`qortex.service`, 8400) + MCP Streamable HTTP (`qortex-mcp.service`, 8401)
- Add 3 new config variables (`qortex_mcp_enabled`, `qortex_mcp_port`, `qortex_mcp_host`) to config reference
- Add MCP service section to qortex.md with systemd unit, gateway config injection, and verification commands
- Add troubleshooting section for MCP service
- Update architecture overview and generated files table

## Test plan
- [ ] Verify MkDocs builds without errors
- [ ] Confirm all internal links resolve
- [ ] Check config variable table renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)