### PR TITLE
fix: wire QORTEX_GRAPH=memgraph into sandbox provisioning

### DIFF
--- a/ansible/roles/gateway/tasks/main.yml
+++ b/ansible/roles/gateway/tasks/main.yml
@@ -414,6 +414,8 @@
       {% endif %}
       # Load secrets from /etc/openclaw/secrets.env (- prefix = don't fail if missing)
       EnvironmentFile=-/etc/openclaw/secrets.env
+      # Load qortex env vars (graph backend, extraction, vec config)
+      EnvironmentFile=-/etc/openclaw/qortex.env
       # Load qortex OTEL env vars (- prefix = don't fail if missing)
       EnvironmentFile=-/etc/openclaw/qortex-otel.env
       {% if overlay_enabled | default(true) | bool and not (overlay_yolo_unsafe | default(false) | bool) %}

--- a/ansible/roles/qortex/templates/qortex.env.j2
+++ b/ansible/roles/qortex/templates/qortex.env.j2
@@ -18,9 +18,10 @@ QORTEX_HMAC_SECRET={{ qortex_hmac_secret }}
 # Extraction strategy
 QORTEX_EXTRACTION={{ qortex_extraction | default('spacy') }}
 
-# Memgraph (when enabled)
+# Memgraph graph backend (when enabled)
 {% if memgraph_enabled | default(false) | bool %}
-MEMGRAPH_HOST=localhost
+QORTEX_GRAPH=memgraph
+MEMGRAPH_HOST={{ memgraph_host | default('localhost') }}
 MEMGRAPH_PORT={{ memgraph_bolt_port | default(7687) }}
 MEMGRAPH_USER={{ memgraph_user | default('memgraph') }}
 MEMGRAPH_PASSWORD={{ memgraph_password | default('memgraph') }}


### PR DESCRIPTION
## Summary

- Add `QORTEX_GRAPH=memgraph` to `qortex.env.j2` so the backend selector is set when `memgraph_enabled` is true
- Template `MEMGRAPH_HOST` via ansible var instead of hardcoded `localhost`
- Add `EnvironmentFile=-/etc/openclaw/qortex.env` to the gateway systemd unit so it picks up graph backend config

Previously, `QORTEX_GRAPH=memgraph` only existed in `qortex-otel.env.j2`, coupling graph backend selection to OTEL being enabled. The gateway unit also didn't load `qortex.env` at all, so even connection vars like `MEMGRAPH_HOST` weren't available to the gateway subprocess.

After this change, all three services (gateway, qortex.service, qortex-mcp.service) get Memgraph env vars from `qortex.env` regardless of OTEL configuration.

## Test plan

- [ ] `bilrost up` with `memgraph: true` in profile
- [ ] Verify `/etc/openclaw/qortex.env` contains `QORTEX_GRAPH=memgraph` + connection vars
- [ ] Verify gateway process has `QORTEX_GRAPH=memgraph` in its environment (`tr '\0' '\n' < /proc/$(pgrep -f gateway)/environ | grep QORTEX_GRAPH`)
- [ ] Verify qortex MCP subprocess connects to Memgraph (check logs for Memgraph backend init)
- [ ] Verify live indexing persists nodes to Memgraph (query via Cypher after a session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)